### PR TITLE
handle the case were the token passed in is a unicode string.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ zope.schema Changelog
 4.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Attempt to gracefully handle the case where a unicode string is passed 
+  into SimpleTerm.
 
 
 4.4.0 (2014-01-22)

--- a/src/zope/schema/vocabulary.py
+++ b/src/zope/schema/vocabulary.py
@@ -42,9 +42,14 @@ class SimpleTerm(object):
         # In Python 3 str(bytes) returns str(repr(bytes)), which is not what
         # we want here. On the other hand, we want to try to keep the token as
         # readable as possible.
-        self.token = str(token) \
-            if not isinstance(token, bytes) \
-            else str(token.decode('ascii', 'ignore'))
+        self.token = token
+        if not isinstance(token, bytes):
+            if isinstance(token, unicode):
+                self.token = token.encode('ascii', 'ignore')
+            else:
+                self.token = str(token)
+        else:
+            self.token = str(token.decode('ascii', 'ignore'))
         self.title = title
         if title is not None:
             directlyProvides(self, ITitledTokenizedTerm)


### PR DESCRIPTION
I struggled on whether or not this code change should be in my code or in here but I think its to more peoples benefit that we attempt to handle unicode terms. Slightly nervous about this fix since it involves unicode and sensitive stuff. All tests are ok though.
