### PR TITLE
Fix description of min max field: actually, max value is included, not excluded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ zope.schema Changelog
 4.4.2 (unreleased)
 ------------------
 
+- Fix description of min max field: actually, max value is included, not excluded.
+
 - TBD
 
 

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -363,7 +363,7 @@ class IInt(IMinMax, IField):
         )
 
     max = Int(
-        title=_("End of the range (excluding the value itself)"),
+        title=_("End of the range (including the value itself)"),
         required=False,
         default=None
         )


### PR DESCRIPTION
cf https://github.com/zopefoundation/zope.schema/blob/master/src/zope/schema/_bootstrapfields.py#l315
