### PR TITLE
Add Python 3.6, drop Python 3.3, 100% coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ exclude_lines =
     pragma: no cover
     if __name__ == '__main__':
     raise NotImplementedError
+    raise AssertionError

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = zope.schema
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ parts
 *.egg-info
 .tox
 .coverage
+htmlcov/
 nosetests.xml
 coverage.xml
 devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,29 @@
 language: python
 sudo: false
-matrix:
-  include:
-    - python: 3.5
-      env: TOXENV=py35
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=pypy
-    - TOXENV=pypy3
-    - TOXENV=coverage
-    - TOXENV=docs
-install:
-    - pip install tox
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy-5.6.0
+
 script:
-    - tox
+  - coverage run -m zope.testrunner --test-path=src
+  - sphinx-build                         -b html    -d docs/_build/doctrees docs docs/_build/html
+  - coverage run -a `which sphinx-build` -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test,docs]"
+
+
+cache: pip
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes
 
 - Add support for Python 3.5 and 3.6.
 
+- Drop support for 'setup.py test'. Use zope.testrunner instead.
+
 
 4.4.2 (2014-09-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ Changes
 4.5.0 (unreleased)
 ------------------
 
-- Drop support for Python 2.6 and 3.2.
+- Drop support for Python 2.6, 3.2, and 3.3.
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
 
 4.4.2 (2014-09-04)

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -30,7 +30,10 @@ Conversion from Unicode:
 
    >>> from zope.schema import Bytes
    >>> obj = Bytes(constraint=lambda v: b'x' in v)
-   >>> obj.fromUnicode(u" foo x.y.z bat")
+   >>> result = obj.fromUnicode(u" foo x.y.z bat")
+   >>> isinstance(result, bytes)
+   True
+   >>> str(result.decode("ascii"))
    ' foo x.y.z bat'
    >>> obj.fromUnicode(u" foo y.z bat")
    Traceback (most recent call last):
@@ -167,8 +170,11 @@ Conversion from Unicode enforces the constraint:
    Traceback (most recent call last):
    ...
    ConstraintNotSatisfied: baz
-   >>> t.fromUnicode(u"foo")
-   u'foo'
+   >>> result = t.fromUnicode(u"foo")
+   >>> isinstance(result, bytes)
+   False
+   >>> print(result)
+   foo
 
 By default, ValueErrors are thrown if duplicate values or tokens
 are passed in. If you are using this vocabulary as part of a form
@@ -189,9 +195,9 @@ Validation ensures that the pattern is matched:
 
    >>> from zope.schema import URI
    >>> uri = URI(__name__='test')
-   >>> uri.validate(b"http://www.python.org/foo/bar")
-   >>> uri.validate(b"DAV:")
-   >>> uri.validate(b"www.python.org/foo/bar")
+   >>> uri.validate("http://www.python.org/foo/bar")
+   >>> uri.validate("DAV:")
+   >>> uri.validate("www.python.org/foo/bar")
    Traceback (most recent call last):
    ...
    InvalidURI: www.python.org/foo/bar

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -69,7 +69,7 @@ is to define some data:
 .. doctest::
 
    >>> title = u'Zope 3 Website'
-   >>> url = b'http://dev.zope.org/Zope3'
+   >>> url = 'http://dev.zope.org/Zope3'
 
 Now we, get the fields from the interface:
 
@@ -168,8 +168,8 @@ Now we want a class that adheres to the ``IContact`` schema:
 
 .. doctest::
 
-   >>> class Contact(object):
-   ...     zope.interface.implements(IContact)
+   >>> @zope.interface.implementer(IContact)
+   ... class Contact(object):
    ...
    ...     def __init__(self, first, last, email, address, pc):
    ...         self.first = first

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -94,8 +94,8 @@ When we set a valid value for `a` we still get the same error for `b`:
    2
    >>> errors[0][0]
    'a'
-   >>> errors[0][1].doc()
-   u'Value is too big'
+   >>> print(errors[0][1].doc())
+   Value is too big
    >>> errors[0][1].__class__.__name__
    'TooBig'
    >>> errors[0][1].args

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ ignore-files=examples.py
 [aliases]
 dev = develop easy_install zope.schema[testing]
 docs = easy_install zope.schema[docs]
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -27,44 +27,6 @@ def read(*rnames):
         return f.read()
 
 
-def _modname(path, base, name=''):
-    if path == base:
-        return name
-    dirname, basename = os.path.split(path)
-    return _modname(dirname, base, basename + '.' + name)
-
-
-def alltests():
-    import logging
-    import pkg_resources
-    import unittest
-
-    class NullHandler(logging.Handler):
-        level = 50
-
-        def emit(self, record):
-            pass
-
-    logging.getLogger().addHandler(NullHandler())
-
-    suite = unittest.TestSuite()
-    base = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('zope.schema')).location
-    for dirpath, dirnames, filenames in os.walk(base):
-        if os.path.basename(dirpath) == 'tests':
-            for filename in filenames:
-                if filename.endswith('.py') and filename.startswith('test'):
-                    mod = __import__(
-                        _modname(dirpath, base, os.path.splitext(filename)[0]),
-                        {}, {}, ['*'])
-                    suite.addTest(mod.test_suite())
-        elif 'tests.py' in filenames:
-            continue
-            mod = __import__(_modname(dirpath, base, 'tests'), {}, {}, ['*'])
-            suite.addTest(mod.test_suite())
-    return suite
-
-
 REQUIRES = [
     'setuptools',
     'zope.interface >= 3.6.0',
@@ -72,7 +34,10 @@ REQUIRES = [
 ]
 
 
-TESTS_REQUIRE = ['zope.testing']
+TESTS_REQUIRE = [
+    'zope.testing',
+    'zope.testrunner',
+]
 
 
 setup(
@@ -98,9 +63,9 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Zope3",
@@ -108,11 +73,12 @@ setup(
     ],
     include_package_data = True,
     zip_safe = False,
-    test_suite='__main__.alltests',
     tests_require=TESTS_REQUIRE,
     extras_require={
-        'docs': ['Sphinx'],
+        'docs': [
+            'Sphinx',
+            'repoze.sphinx.autointerface',
+        ],
         'test': TESTS_REQUIRE,
-        'testing': TESTS_REQUIRE + ['nose', 'coverage'],
     },
 )

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -128,16 +128,16 @@ class Field(Attribute):
 
         >>> from zope.schema._bootstrapfields import Field
         >>> f = Field()
-        >>> f.__doc__, f.title, f.description
-        ('', u'', u'')
+        >>> f.__doc__, str(f.title), str(f.description)
+        ('', '', '')
 
         >>> f = Field(title=u'sample')
-        >>> f.__doc__, f.title, f.description
-        (u'sample', u'sample', u'')
+        >>> str(f.__doc__), str(f.title), str(f.description)
+        ('sample', 'sample', '')
 
         >>> f = Field(title=u'sample', description=u'blah blah\\nblah')
-        >>> f.__doc__, f.title, f.description
-        (u'sample\\n\\nblah blah\\nblah', u'sample', u'blah blah\\nblah')
+        >>> str(f.__doc__), str(f.title), str(f.description)
+        ('sample\\n\\nblah blah\\nblah', 'sample', 'blah blah\\nblah')
         """
         __doc__ = ''
         if title:
@@ -332,8 +332,11 @@ class Text(MinMaxLen, Field):
         Traceback (most recent call last):
         ...
         WrongType: ('foo x spam', <type 'unicode'>, '')
-        >>> t.fromUnicode(u"foo x spam")
-        u'foo x spam'
+        >>> result = t.fromUnicode(u"foo x spam")
+        >>> isinstance(result, bytes)
+        False
+        >>> str(result)
+        'foo x spam'
         >>> t.fromUnicode(u"foo spam")
         Traceback (most recent call last):
         ...

--- a/src/zope/schema/_bootstrapinterfaces.py
+++ b/src/zope/schema/_bootstrapinterfaces.py
@@ -114,7 +114,7 @@ class IContextAwareDefaultFactory(zope.interface.Interface):
 
 
 class NO_VALUE(object):
-    def __repr__(self):
+    def __repr__(self): # pragma: no cover
         return '<NO_VALUE>'
 
 NO_VALUE = NO_VALUE()

--- a/src/zope/schema/tests/states.py
+++ b/src/zope/schema/tests/states.py
@@ -117,14 +117,3 @@ class StateVocabulary(object):
 
     def getTerm(self, value):
         return _states[value]
-
-
-class StateSelectionField(Choice):
-
-    vocabulary = StateVocabulary()
-
-    def __init__(self, **kw):
-        super(StateSelectionField, self).__init__(
-            vocabulary=StateSelectionField.vocabulary,
-            **kw)
-        self.vocabularyName = "states"

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -267,10 +267,8 @@ class FieldTests(unittest.TestCase):
     def test_validate_missing_not_required(self):
         missing = object()
 
-        def _fail(value):
-            return False
         field = self._makeOne(
-            required=False, missing_value=missing, constraint=_fail,
+            required=False, missing_value=missing, constraint=lambda x: False,
         )
         self.assertEqual(field.validate(missing), None)  # doesn't raise
 
@@ -278,28 +276,22 @@ class FieldTests(unittest.TestCase):
         from zope.schema._bootstrapinterfaces import RequiredMissing
         missing = object()
 
-        def _fail(value):
-            return False
         field = self._makeOne(
-            required=True, missing_value=missing, constraint=_fail,
+            required=True, missing_value=missing, constraint=lambda x: False,
         )
         self.assertRaises(RequiredMissing, field.validate, missing)
 
     def test_validate_wrong_type(self):
         from zope.schema._bootstrapinterfaces import WrongType
 
-        def _fail(value):
-            return False
-        field = self._makeOne(required=True, constraint=_fail)
+        field = self._makeOne(required=True, constraint=lambda x: False)
         field._type = str
         self.assertRaises(WrongType, field.validate, 1)
 
     def test_validate_constraint_fails(self):
         from zope.schema._bootstrapinterfaces import ConstraintNotSatisfied
 
-        def _fail(value):
-            return False
-        field = self._makeOne(required=True, constraint=_fail)
+        field = self._makeOne(required=True, constraint=lambda x: False)
         field._type = int
         self.assertRaises(ConstraintNotSatisfied, field.validate, 1)
 
@@ -401,7 +393,7 @@ class ContainerTests(unittest.TestCase):
 
         class Dummy(object):
             def __contains__(self, item):
-                return False
+                raise AssertionError("Not called")
         cont._validate(Dummy())  # doesn't raise
 
     def test__validate_not_collection_but_iterable(self):
@@ -432,7 +424,7 @@ class IterableTests(ContainerTests):
 
         class Dummy(object):
             def __contains__(self, item):
-                return False
+                raise AssertionError("Not called")
         self.assertRaises(NotAnIterator, itr._validate, Dummy())
 
 
@@ -803,20 +795,3 @@ class DummyInst(object):
     def validate(self, value):
         if self._exc is not None:
             raise self._exc()
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(ValidatedPropertyTests),
-        unittest.makeSuite(DefaultPropertyTests),
-        unittest.makeSuite(FieldTests),
-        unittest.makeSuite(ContainerTests),
-        unittest.makeSuite(IterableTests),
-        unittest.makeSuite(OrderableTests),
-        unittest.makeSuite(MinMaxLenTests),
-        unittest.makeSuite(TextTests),
-        unittest.makeSuite(TextLineTests),
-        unittest.makeSuite(PasswordTests),
-        unittest.makeSuite(BoolTests),
-        unittest.makeSuite(IntTests),
-    ))

--- a/src/zope/schema/tests/test__bootstrapinterfaces.py
+++ b/src/zope/schema/tests/test__bootstrapinterfaces.py
@@ -16,9 +16,7 @@ import unittest
 
 def _skip_under_py3(testcase):
     from zope.schema._compat import PY3
-    if not PY3:
-        return testcase
-
+    return unittest.skipIf(PY3, "Not under Python 3")(testcase)
 
 class ValidationErrorTests(unittest.TestCase):
 
@@ -60,9 +58,3 @@ class ValidationErrorTests(unittest.TestCase):
         self.assertEqual(left == right, False)
         self.assertEqual(left == left, True)
         self.assertEqual(right == right, True)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(ValidationErrorTests),
-    ))

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -933,7 +933,7 @@ class ChoiceTests(unittest.TestCase):
         @implementer(IContextSourceBinder)
         class SampleContextSourceBinder(object):
             def __call__(self, context):
-                pass
+                raise AssertionError("This is not called")
 
         choice = self._makeOne(source=SampleContextSourceBinder())
         self.assertRaises(TypeError, choice.validate, 1)
@@ -1675,14 +1675,9 @@ class ObjectTests(unittest.TestCase):
 
     def _getErrors(self, f, *args, **kw):
         from zope.schema.interfaces import WrongContainedType
-        try:
+        with self.assertRaises(WrongContainedType) as e:
             f(*args, **kw)
-        except WrongContainedType as e:
-            try:
-                return e.args[0]
-            except:
-                return []
-        self.fail('Expected WrongContainedType Error')
+        return e.exception.args[0]
 
     def _makeCycles(self):
         from zope.interface import Interface
@@ -2063,21 +2058,16 @@ def _makeSampleVocabulary():
     class SampleVocabulary(object):
 
         def __iter__(self):
-            return iter([self.getTerm(x) for x in range(0, 10)])
+            raise AssertionError("Not implemented")
 
         def __contains__(self, value):
             return 0 <= value < 10
 
-        def __len__(self):
+        def __len__(self): # pragma: no cover
             return 10
 
         def getTerm(self, value):
-            if value in self:
-                t = SampleTerm()
-                t.value = value
-                t.double = 2 * value
-                return t
-            raise LookupError("no such value: %r" % value)
+            raise AssertionError("Not implemented")
 
     return SampleVocabulary()
 
@@ -2092,30 +2082,3 @@ def _makeDummyRegistry(v):
         def get(self, object, name):
             return self._vocabulary
     return DummyRegistry(v)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(BytesTests),
-        unittest.makeSuite(ASCIITests),
-        unittest.makeSuite(BytesLineTests),
-        unittest.makeSuite(ASCIILineTests),
-        unittest.makeSuite(FloatTests),
-        unittest.makeSuite(DecimalTests),
-        unittest.makeSuite(DatetimeTests),
-        unittest.makeSuite(DateTests),
-        unittest.makeSuite(TimedeltaTests),
-        unittest.makeSuite(TimeTests),
-        unittest.makeSuite(ChoiceTests),
-        unittest.makeSuite(InterfaceFieldTests),
-        unittest.makeSuite(AbstractCollectionTests),
-        unittest.makeSuite(TupleTests),
-        unittest.makeSuite(ListTests),
-        unittest.makeSuite(SetTests),
-        unittest.makeSuite(FrozenSetTests),
-        unittest.makeSuite(ObjectTests),
-        unittest.makeSuite(DictTests),
-        unittest.makeSuite(URITests),
-        unittest.makeSuite(IdTests),
-        unittest.makeSuite(DottedNameTests),
-    ))

--- a/src/zope/schema/tests/test_accessors.py
+++ b/src/zope/schema/tests/test_accessors.py
@@ -151,7 +151,7 @@ class FieldReadAccessorTests(unittest.TestCase):
 
         class Foo(object):
             def getter(self):
-                return '123'
+                raise AssertionError("Not called")
         self.assertRaises(TypeError, getter.set, Foo(), '456')
 
     def test_set_no_writer(self):
@@ -163,7 +163,7 @@ class FieldReadAccessorTests(unittest.TestCase):
 
         class Foo(object):
             def getter(self):
-                return '123'
+                raise AssertionError("Not called")
 
         self.assertRaises(AttributeError, getter.set, Foo(), '456')
 
@@ -305,11 +305,3 @@ class Test_accessors(unittest.TestCase):
         self.assertEqual(info['optional'], ())
         self.assertEqual(info['varargs'], None)
         self.assertEqual(info['kwargs'], None)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(FieldReadAccessorTests),
-        unittest.makeSuite(FieldWriteAccessorTests),
-        unittest.makeSuite(Test_accessors),
-    ))

--- a/src/zope/schema/tests/test_equality.py
+++ b/src/zope/schema/tests/test_equality.py
@@ -28,9 +28,3 @@ class FieldEqualityTests(unittest.TestCase):
 
         for cls in (Int, Text):
             self.assertEqual(_makeOne(cls), _makeOne(cls))
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(FieldEqualityTests),
-        ))

--- a/src/zope/schema/tests/test_fieldproperty.py
+++ b/src/zope/schema/tests/test_fieldproperty.py
@@ -517,7 +517,7 @@ class FieldPropertyStoredThroughFieldTests(_Base, _Integration):
                 return default
 
             def set(self, inst, value):
-                if self.readonly:
+                if self.readonly: # pragma: no cover
                     raise ValueError
                 setattr(inst, 'faux', value)
 
@@ -658,11 +658,3 @@ class CreateFieldPropertiesTests(unittest.TestCase):
         self.assertFalse(hasattr(Dummy, 'date'))
         self.assertFalse(hasattr(Dummy, 'code'))
         self.assertTrue(hasattr(Dummy, 'title'))
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(FieldPropertyTests),
-        unittest.makeSuite(FieldPropertyStoredThroughFieldTests),
-        unittest.makeSuite(CreateFieldPropertiesTests),
-    ))

--- a/src/zope/schema/tests/test_interfaces.py
+++ b/src/zope/schema/tests/test_interfaces.py
@@ -88,10 +88,3 @@ class Test__fields(unittest.TestCase):
             self._callFUT([Text(), Bytes(), Int(), Float(), Decimal(), 0]),
             False
         )
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test__is_field),
-        unittest.makeSuite(Test__fields),
-    ))

--- a/src/zope/schema/tests/test_schema.py
+++ b/src/zope/schema/tests/test_schema.py
@@ -212,7 +212,7 @@ class Test_getSchemaValidationErrors(unittest.TestCase):
 
         class INoFields(Interface):
             def method():
-                pass
+                "A method."
             attr = Attribute('ignoreme')
 
         errors = self._callFUT(INoFields, object())
@@ -262,14 +262,3 @@ class Test_getSchemaValidationErrors(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0][0], 'value')
         self.assertEqual(errors[0][1].__class__, TooSmall)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(Test_getFields),
-        unittest.makeSuite(Test_getFieldsInOrder),
-        unittest.makeSuite(Test_getFieldNames),
-        unittest.makeSuite(Test_getFieldNamesInOrder),
-        unittest.makeSuite(Test_getValidationErrors),
-        unittest.makeSuite(Test_getSchemaValidationErrors),
-    ))

--- a/src/zope/schema/tests/test_states.py
+++ b/src/zope/schema/tests/test_states.py
@@ -98,9 +98,3 @@ class StateSelectionTest(unittest.TestCase):
         self.assertTrue(bound.vocabularyName is None)
         self.assertTrue(verifyObject(IVocabulary, bound.vocabulary))
         self.assertTrue("AL" in bound.vocabulary)
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(StateSelectionTest),
-    ))

--- a/src/zope/schema/tests/test_vocabulary.py
+++ b/src/zope/schema/tests/test_vocabulary.py
@@ -602,21 +602,16 @@ def _makeSampleVocabulary():
     class SampleVocabulary(object):
 
         def __iter__(self):
-            return iter([self.getTerm(x) for x in range(0, 10)])
+            raise AssertionError("Not called")
 
         def __contains__(self, value):
             return 0 <= value < 10
 
-        def __len__(self):
+        def __len__(self): # pragma: no cover
             return 10
 
         def getTerm(self, value):
-            if value in self:
-                t = SampleTerm()
-                t.value = value
-                t.double = 2 * value
-                return t
-            raise LookupError("no such value: %r" % value)
+            raise AssertionError("Not called.")
 
     return SampleVocabulary()
 
@@ -626,17 +621,5 @@ def _makeDummyRegistry():
 
     class DummyRegistry(VocabularyRegistry):
         def get(self, object, name):
-            v = _makeSampleVocabulary()
-            v.object = object
-            v.name = name
-            return v
+            raise AssertionError("Not called")
     return DummyRegistry()
-
-
-def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(SimpleTermTests),
-        unittest.makeSuite(SimpleVocabularyTests),
-        unittest.makeSuite(TreeVocabularyTests),
-        unittest.makeSuite(RegistryTests),
-    ))

--- a/tox.ini
+++ b/tox.ini
@@ -1,46 +1,37 @@
 [tox]
-envlist = 
+envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py27,jython,pypy,coverage
-    py27,py33,py34,py35,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,pypy,pypy3,coverage,docs
 
 [testenv]
 deps =
-    zope.schema[test]
-commands = 
-    python setup.py test -q
-
-[testenv:jython]
-commands = 
-   jython setup.py test -q
+    .[test]
+commands =
+    zope-testrunner --test-path=src
 
 [testenv:coverage]
 basepython =
     python2.7
-commands = 
+commands =
 #   The installed version messes up nose's test discovery / coverage reporting
 #   So, we uninstall that from the environment, and then install the editable
 #   version, before running nosetests.
     pip uninstall -y zope.schema
     pip install -e .
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
 deps =
-    zope.schema[test]
-    zope.interface>=3.6.0
-    zope.event
-    zope.testing
-    nose
+    .[test]
     coverage
-    nosexcover
 
 [testenv:docs]
 basepython =
     python2.7
-commands = 
+commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    zope.interface>=3.6.0
+    .[test,docs]
     Sphinx
     repoze.sphinx.autointerface


### PR DESCRIPTION
Use zope.testrunner because of the namespace package issue on recent versions of Python. 

Enable coverage reporting on Travis.

Run doctests on all versions on Travis. --- This is the WIP part, I haven't run these tests locally yet.

Python 3.3 dropped because Sphinx dropped it.

Fixes #30