### PR TITLE
Point to https://zopeschema.readthedocs.io/ instead of docs.zope.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,4 +21,4 @@ its value and provide a validation method.  Besides you can optionally
 specify characteristics such as its value being read-only or not
 required.
 
-See http://docs.zope.org/zope.schema/ for more information.
+See https://zopeschema.readthedocs.io/ for more information.


### PR DESCRIPTION
Fixes #21.