### PR TITLE
Fixes for #33 (Datetime field docs typo)

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -125,10 +125,10 @@ Conversion from Unicode:
    ...
    ValueError: invalid literal for Decimal(): 1.25.6
 
-DateTime
+Datetime
 ########
 
-:class:`zope.schema.DateTime` fields contain binary data, represented
+:class:`zope.schema.Datetime` fields contain binary data, represented
 as a a Python :class:`datetime.datetime`.
 
 Date

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -384,7 +384,7 @@ class IDecimal(IMinMax, IField):
 
 
 class IDatetime(IMinMax, IField):
-    """Field containing a DateTime."""
+    """Field containing a datetime."""
 
 
 class IDate(IMinMax, IField):


### PR DESCRIPTION
There's another typo I saw somewhere, I'll add it to this PR