### PR TITLE
re #36: Make fields hashable in Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 4.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make fields hashable in Python 3 (#36).
+  This fix should be improved according to the comments for the next release
+  that allows backwards incompatibilities in Python 2.
 
 
 4.5.0 (2017-07-10)

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -184,6 +184,19 @@ class Field(Attribute):
             except StopValidation:
                 pass
 
+    def __hash__(self):
+        # See <https://github.com/zopefoundation/zope.schema/issues/36>.
+        # XXX Good solution that is backwards-incompatible, though:
+        # Depend on an immutable subset of the equality criteria used in
+        # __eq__ to ensure that instances comparing equal by value have equal
+        # hash values, which boils down to the field type alone.
+
+        # return hash(type(self))
+
+        # XXX Temporary solution to make fields hashable in Python 3 without
+        # breaking backwards compatibility in Python 2:
+        return id(self)
+
     def __eq__(self, other):
         # should be the same type
         if type(self) != type(other):

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -364,6 +364,26 @@ class FieldTests(unittest.TestCase):
         field.set(inst, 'AFTER')
         self.assertEqual(inst.extant, 'AFTER')
 
+    def test_is_hashable(self):
+        field = self._makeOne()
+        hash(field)  # doesn't raise
+
+    # XXX See <https://github.com/zopefoundation/zope.schema/issues/36>.
+    # Test should work when the final hash implementation is used.
+    # def test_equal_instances_have_same_hash(self):
+    #     field1 = self._makeOne()
+    #     field2 = self._makeOne()
+    #     assert field1 is not field2
+    #     assert field1 == field2
+    #     self.assertTrue(hash(field1) == hash(field2))
+
+    def test_hash_varies_across_unequal_instances(self):
+        field1 = self._makeOne(title=u'foo')
+        field2 = self._makeOne(title=u'bar')
+        assert field1 is not field2
+        assert field1 != field2
+        self.assertFalse(hash(field1) == hash(field2))
+
 
 class ContainerTests(unittest.TestCase):
 


### PR DESCRIPTION
This fix should be improved according to the comments for the next release
that allows backwards incompatibilities in Python 2.

[See #36 and also #39 as an alternative implemenation]
