### PR TITLE
``Field`` instances are hashable on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ Changes
 4.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ``Field`` instances are hashable on Python 3, and use a defined
+  hashing algorithm that matches what equality does on all versions of
+  Python. Previously, on Python 2, fields were hashed based on their
+  identity. This violated the rule that equal objects should have
+  equal hashes, and now they do. Since having equal hashes does not
+  imply that the objects are equal, this is not expected to be a
+  compatibility problem. See `issue 36
+  <https://github.com/zopefoundation/zope.schema/issues/36>`_.
 
 
 4.5.0 (2017-07-10)

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -364,6 +364,34 @@ class FieldTests(unittest.TestCase):
         field.set(inst, 'AFTER')
         self.assertEqual(inst.extant, 'AFTER')
 
+    def test_is_hashable(self):
+        field = self._makeOne()
+        hash(field)  # doesn't raise
+
+    def test_equal_instances_have_same_hash(self):
+        # Equal objects should have equal hashes
+        field1 = self._makeOne()
+        field2 = self._makeOne()
+        self.assertIsNot(field1, field2)
+        self.assertEqual(field1, field2)
+        self.assertEqual(hash(field1), hash(field2))
+
+    def test_hash_across_unequal_instances(self):
+        # Hash equality does not imply equal objects.
+        # Our implementation only considers property names,
+        # not values. That's OK, a dict still does the right thing.
+        field1 = self._makeOne(title=u'foo')
+        field2 = self._makeOne(title=u'bar')
+        self.assertIsNot(field1, field2)
+        self.assertNotEqual(field1, field2)
+        self.assertEqual(hash(field1), hash(field2))
+
+        d = {field1: 42}
+        self.assertIn(field1, d)
+        self.assertEqual(42, d[field1])
+        self.assertNotIn(field2, d)
+        with self.assertRaises(KeyError):
+            d[field2]
 
 class ContainerTests(unittest.TestCase):
 


### PR DESCRIPTION
They use a defined hashing algorithm that matches what equality does on all versions of Python. Previously, on Python 2, fields were hashed based on their identity. This violated the rule that equal objects should have equal hashes, and now they do. Since having equal hashes does not imply that the objects are equal, this is not expected to be a compatibility problem.

This is an alternative to #38 ; I don't expect that there will be any practical compatibility issues making the fix the way the language spec intends. Included tests with a dict show that there shouldn't be false matches even with equal hashes.

Fixes #36