### PR TITLE
Handle Unicode token values with non-ascii chars.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,13 @@ Changes
   ``max`` values (they must still specify a ``default`` value). See
   `issue 9 <https://github.com/zopefoundation/zope.schema/issues/9>`_.
 
+- ``Choice``, ``SimpleVocabulary`` and  ``SimpleTerm`` all gracefully
+  handle using Unicode token values with non-ASCII characters by encoding
+  them with the ``backslashreplace`` error handler. See `issue 15
+  <https://github.com/zopefoundation/zope.schema/issues/15>`_ and `PR
+  6 <https://github.com/zopefoundation/zope.schema/pull/6>`_.
+
+
 4.5.0 (2017-07-10)
 ------------------
 

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -592,13 +592,14 @@ class ITokenizedTerm(ITerm):
     """
 
     # Should be a ``zope.schema.ASCIILine``, but `ASCIILine` is not a bootstrap
-    # field.
+    # field. `ASCIILine` is a type of NativeString.
     token = Attribute(
         "token",
         """Token which can be used to represent the value on a stream.
 
-        The value of this attribute must be a non-empty 7-bit string.
-        Control characters are not allowed.
+        The value of this attribute must be a non-empty 7-bit native string
+        (i.e., the ``str`` type on both Python 2 and 3).
+        Control characters, including newline, are not allowed.
         """)
 
 

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -802,6 +802,18 @@ class ChoiceTests(unittest.TestCase):
         self.assertEqual(sorted(choose.vocabulary.by_value.keys()), [1, 2])
         self.assertEqual(sorted(choose.source.by_value.keys()), [1, 2])
 
+    def test_ctor_w_unicode_non_ascii_values(self):
+        values = [u'K\xf6ln', u'D\xfcsseldorf', 'Bonn']
+        choose = self._makeOne(values=values)
+        self.assertEqual(sorted(choose.vocabulary.by_value.keys()),
+                         sorted(values))
+        self.assertEqual(sorted(choose.source.by_value.keys()),
+                         sorted(values))
+        self.assertEqual(
+            sorted(choose.vocabulary.by_token.keys()),
+            sorted([x.encode('ascii', 'backslashreplace').decode('ascii') for x in values]))
+
+
     def test_ctor_w_named_vocabulary(self):
         choose = self._makeOne(vocabulary="vocab")
         self.assertEqual(choose.vocabularyName, 'vocab')

--- a/src/zope/schema/tests/test_vocabulary.py
+++ b/src/zope/schema/tests/test_vocabulary.py
@@ -58,6 +58,13 @@ class SimpleTermTests(unittest.TestCase):
         self.assertEqual(term.token, 'term')
         self.assertFalse(ITitledTokenizedTerm.providedBy(term))
 
+    def test_unicode_non_ascii_value(self):
+        from zope.schema.interfaces import ITitledTokenizedTerm
+        term = self._makeOne(u'Snowman \u2603')
+        self.assertEqual(term.value, u'Snowman \u2603')
+        self.assertEqual(term.token, 'Snowman \\u2603')
+        self.assertFalse(ITitledTokenizedTerm.providedBy(term))
+
 
 class SimpleVocabularyTests(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #15 and fixes #6

I went with backslashreplace because I couldn't find anything that was portable and operated on textual data (binascii and quopri need binary data; namereplace needs Python 3.5+).

The ITerm comment claims that token should be an IASCIILine, which is a native string, not necessarily text, so that's what I kept it here.

Note that we're not actually enforcing that the value is an IASCIILine. Passing in control characters would still be allowed as before.