### PR TITLE
Add the ability for Object to check schema invariants.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changes
 4.5.1 (unreleased)
 ------------------
 
+- ``Object`` instances call their schema's ``validateInvariants``
+  method by default to collect errors from functions decorated with
+  ``@invariant`` when validating. This can be disabled by passing
+  ``validate_invariants=False`` to the ``Object`` constructor. See
+  `issue 10 <https://github.com/zopefoundation/zope.schema/issues/10>`_.
+
 - ``Field`` instances are hashable on Python 3, and use a defined
   hashing algorithm that matches what equality does on all versions of
   Python. Previously, on Python 2, fields were hashed based on their

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ version = '.'.join(release.split('.')[:2])
 exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -617,7 +617,7 @@ class Object(Field):
 
     def __init__(self, schema, **kw):
         """
-        Object(schema, validate_invariants=True, **kwargs)
+        Object(schema, *, validate_invariants=True, **kwargs)
 
         Create an `~.IObject` field. The keyword arguments are as for `~.Field`.
 
@@ -649,7 +649,7 @@ class Object(Field):
             except Invalid:
                 # validateInvariants raises a wrapper error around
                 # all the errors it got if it got errors, in addition
-                # no appending them to the errors list. We don't want
+                # to appending them to the errors list. We don't want
                 # that, we raise our own error.
                 pass
 

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -27,6 +27,7 @@ from zope.event import notify
 from zope.interface import classImplements
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import Invalid
 from zope.interface.interfaces import IInterface
 from zope.interface.interfaces import IMethod
 
@@ -615,10 +616,21 @@ class Object(Field):
     __doc__ = IObject.__doc__
 
     def __init__(self, schema, **kw):
+        """
+        Object(schema, validate_invariants=True, **kwargs)
+
+        Create an `~.IObject` field. The keyword arguments are as for `~.Field`.
+
+        .. versionchanged:: 4.6.0
+           Add the keyword argument *validate_invariants*. When true (the default),
+           the schema's ``validateInvariants`` method will be invoked to check
+           the ``@invariant`` properties of the schema.
+        """
         if not IInterface.providedBy(schema):
             raise WrongType
 
         self.schema = schema
+        self.validate_invariants = kw.pop('validate_invariants', True)
         super(Object, self).__init__(**kw)
 
     def _validate(self, value):
@@ -630,6 +642,17 @@ class Object(Field):
 
         # check the value against schema
         errors = _validate_fields(self.schema, value)
+
+        if self.validate_invariants:
+            try:
+                self.schema.validateInvariants(value, errors)
+            except Invalid:
+                # validateInvariants raises a wrapper error around
+                # all the errors it got if it got errors, in addition
+                # no appending them to the errors list. We don't want
+                # that, we raise our own error.
+                pass
+
         if errors:
             raise WrongContainedType(errors, self.__name__)
 

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -535,11 +535,22 @@ class IFrozenSet(IAbstractSet):
 
 
 class IObject(IField):
-    """Field containing an Object value."""
+    """
+    Field containing an Object value.
+
+    .. versionchanged:: 4.6.0
+       Add the *validate_invariants* attribute.
+    """
 
     schema = Attribute(
         "schema",
         _("The Interface that defines the Fields comprising the Object.")
+    )
+
+    validate_invariants = Attribute(
+        "validate_invariants",
+        _("A boolean that says whether ``schema.validateInvariants`` "
+          "is called from ``self.validate()``. The default is true.")
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,5 +33,3 @@ commands =
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
     .[test,docs]
-    Sphinx
-    repoze.sphinx.autointerface


### PR DESCRIPTION
Leave the ability to opt-out of that in case it causes unexpected breakage.

Fixes #10.

@tseaver wrote:

>  I am concerned that obscuring the Invalid eror raised by the invariant check is going to lead to hard-to-debug errors, so I haven't committed the patch. 

In Python 3, each contained `Invalid` exception carries its traceback with it, so perhaps this is much less of a concern than it used to be.