### PR TITLE
Give ValidationErrors more context information.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@
   attribute that is set to the field that raised the exception and the
   value that failed validation.
 
+- ``Float``, ``Int`` and ``Decimal`` fields raise ``ValidationError``
+  subclasses for literals that cannot be parsed. These subclasses also
+  subclass ``ValueError`` for backwards compatibility.
+
 - Add a new exception ``SchemaNotCorrectlyImplemented``, a subclass of
   ``WrongContainedType`` that is raised by the ``Object`` field. It
   has a dictionary (``schema_errors``) mapping invalid schema

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,17 @@
   <https://github.com/zopefoundation/zope.schema/issues/15>`_ and `PR
   6 <https://github.com/zopefoundation/zope.schema/pull/6>`_.
 
+- All instances of ``ValidationError`` have a ``field`` and ``value``
+  attribute that is set to the field that raised the exception and the
+  value that failed validation.
+
+- Add a new exception ``SchemaNotCorrectlyImplemented``, a subclass of
+  ``WrongContainedType`` that is raised by the ``Object`` field. It
+  has a dictionary (``schema_errors``) mapping invalid schema
+  attributes to their corresponding exception, and a list
+  (``invariant_errors``) containing the exceptions raised by
+  validating invariants. See `issue 16
+  <https://github.com/zopefoundation/zope.schema/issues/16>`_.
 
 4.5.0 (2017-07-10)
 ==================

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -101,7 +101,27 @@ Conversion from Unicode:
    >>> f.fromUnicode("1.25.6") #doctest: +IGNORE_EXCEPTION_DETAIL
    Traceback (most recent call last):
    ...
-   ValueError: invalid literal for float(): 1.25.6
+   InvalidFloatLiteral: invalid literal for float(): 1.25.6
+
+Int
+###
+
+:class:`zope.schema.Int` fields contain binary data, represented
+as a a Python ``int``.
+
+Conversion from Unicode:
+
+.. doctest::
+
+   >>> from zope.schema import Int
+   >>> f = Int()
+   >>> f.fromUnicode("1")
+   1
+   >>> f.fromUnicode("1.25.6") #doctest: +IGNORE_EXCEPTION_DETAIL
+   Traceback (most recent call last):
+   ...
+   InvalidIntLiteral: invalid literal for int() with base 10: 1.25.6
+
 
 Decimal
 #######
@@ -123,7 +143,7 @@ Conversion from Unicode:
    >>> f.fromUnicode("1.25.6")
    Traceback (most recent call last):
    ...
-   ValueError: invalid literal for Decimal(): 1.25.6
+   InvalidDecimalLiteral: invalid literal for Decimal(): 1.25.6
 
 Datetime
 ########

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -181,7 +181,7 @@ class Field(Attribute):
     def validate(self, value):
         if value == self.missing_value:
             if self.required:
-                raise RequiredMissing(self.__name__)
+                raise RequiredMissing(self.__name__).with_field_and_value(self, value)
         else:
             try:
                 self._validate(value)
@@ -227,10 +227,10 @@ class Field(Attribute):
 
     def _validate(self, value):
         if self._type is not None and not isinstance(value, self._type):
-            raise WrongType(value, self._type, self.__name__)
+            raise WrongType(value, self._type, self.__name__).with_field_and_value(self, value)
 
         if not self.constraint(value):
-            raise ConstraintNotSatisfied(value, self.__name__)
+            raise ConstraintNotSatisfied(value, self.__name__).with_field_and_value(self, value)
 
     def get(self, object):
         return getattr(object, self.__name__)
@@ -257,7 +257,7 @@ class Container(Field):
             try:
                 iter(value)
             except TypeError:
-                raise NotAContainer(value)
+                raise NotAContainer(value).with_field_and_value(self, value)
 
 
 # XXX This class violates the Liskov Substituability Principle:  it
@@ -272,7 +272,7 @@ class Iterable(Container):
         try:
             iter(value)
         except TypeError:
-            raise NotAnIterator(value)
+            raise NotAnIterator(value).with_field_and_value(self, value)
 
 
 class Orderable(object):
@@ -307,10 +307,10 @@ class Orderable(object):
         super(Orderable, self)._validate(value)
 
         if self.min is not None and value < self.min:
-            raise TooSmall(value, self.min)
+            raise TooSmall(value, self.min).with_field_and_value(self, value)
 
         if self.max is not None and value > self.max:
-            raise TooBig(value, self.max)
+            raise TooBig(value, self.max).with_field_and_value(self, value)
 
 
 class MinMaxLen(object):
@@ -330,10 +330,10 @@ class MinMaxLen(object):
         super(MinMaxLen, self)._validate(value)
 
         if self.min_length is not None and len(value) < self.min_length:
-            raise TooShort(value, self.min_length)
+            raise TooShort(value, self.min_length).with_field_and_value(self, value)
 
         if self.max_length is not None and len(value) > self.max_length:
-            raise TooLong(value, self.max_length)
+            raise TooLong(value, self.max_length).with_field_and_value(self, value)
 
 
 @implementer(IFromUnicode)

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -19,6 +19,7 @@ from zope.interface import Attribute
 from zope.interface import providedBy
 from zope.interface import implementer
 
+from zope.schema._bootstrapinterfaces import ValidationError
 from zope.schema._bootstrapinterfaces import ConstraintNotSatisfied
 from zope.schema._bootstrapinterfaces import IContextAwareDefaultFactory
 from zope.schema._bootstrapinterfaces import IFromUnicode
@@ -440,6 +441,9 @@ class Bool(Field):
         self.validate(v)
         return v
 
+class InvalidIntLiteral(ValueError, ValidationError):
+    """Invalid int literal."""
+
 
 @implementer(IFromUnicode)
 class Int(Orderable, Field):
@@ -458,8 +462,11 @@ class Int(Orderable, Field):
         >>> f.fromUnicode("125.6") #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
-        ValueError: invalid literal for int(): 125.6
+        InvalidIntLiteral: invalid literal for int(): 125.6
         """
-        v = int(str)
+        try:
+            v = int(str)
+        except ValueError as v:
+            raise InvalidIntLiteral(*v.args).with_field_and_value(self, str)
         self.validate(v)
         return v

--- a/src/zope/schema/_bootstrapinterfaces.py
+++ b/src/zope/schema/_bootstrapinterfaces.py
@@ -32,6 +32,17 @@ class StopValidation(Exception):
 class ValidationError(zope.interface.Invalid):
     """Raised if the Validation process fails."""
 
+    #: The field that raised the error, if known.
+    field = None
+
+    #: The value that failed validation.
+    value = None
+
+    def with_field_and_value(self, field, value):
+        self.field = field
+        self.value = value
+        return self
+
     def doc(self):
         return self.__class__.__doc__
 

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -663,7 +663,7 @@ class Object(Field):
 
         # schema has to be provided by value
         if not self.schema.providedBy(value):
-            raise SchemaNotProvided
+            raise SchemaNotProvided(self.schema, value).with_field_and_value(self, value)
 
         # check the value against schema
         schema_error_dict = _validate_fields(self.schema, value)

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -72,6 +72,7 @@ from zope.schema.interfaces import WrongType
 from zope.schema.interfaces import WrongContainedType
 from zope.schema.interfaces import NotUnique
 from zope.schema.interfaces import SchemaNotProvided
+from zope.schema.interfaces import SchemaNotCorrectlyImplemented
 from zope.schema.interfaces import SchemaNotFullyImplemented
 from zope.schema.interfaces import InvalidURI
 from zope.schema.interfaces import InvalidId
@@ -157,7 +158,7 @@ class ASCII(NativeString):
         if not value:
             return
         if not max(map(ord, value)) < 128:
-            raise InvalidValue
+            raise InvalidValue().with_field_and_value(self, value)
 
 
 @implementer(IBytesLine)
@@ -214,7 +215,13 @@ class Decimal(Orderable, Field):
         try:
             v = decimal.Decimal(uc)
         except decimal.InvalidOperation:
-            raise ValueError('invalid literal for Decimal(): %s' % uc)
+            exc = ValueError('invalid literal for Decimal(): %s' % uc)
+            exc.value = uc
+            exc.field = self
+            try:
+                raise exc
+            finally:
+                del exc
         self.validate(v)
         return v
 
@@ -236,7 +243,7 @@ class Date(Orderable, Field):
     def _validate(self, value):
         super(Date, self)._validate(value)
         if isinstance(value, datetime):
-            raise WrongType(value, self._type, self.__name__)
+            raise WrongType(value, self._type, self.__name__).with_field_and_value(self, value)
 
 
 @implementer(ITimedelta)
@@ -336,7 +343,7 @@ class Choice(Field):
             except VocabularyRegistryError:
                 raise ValueError("Can't validate value without vocabulary")
         if value not in vocabulary:
-            raise ConstraintNotSatisfied(value, self.__name__)
+            raise ConstraintNotSatisfied(value, self.__name__).with_field_and_value(self, value)
 
 
 _isuri = r"[a-zA-z0-9+.-]+:"  # scheme
@@ -354,7 +361,7 @@ class URI(NativeStringLine):
         if _isuri(value):
             return
 
-        raise InvalidURI(value)
+        raise InvalidURI(value).with_field_and_value(self, value)
 
     def fromUnicode(self, value):
         """ See IFromUnicode.
@@ -384,7 +391,7 @@ class _StrippedNativeStringLine(NativeStringLine):
         try:
             v = v.encode('ascii') # bytes
         except UnicodeEncodeError:
-            raise self._invalid_exc_type(value)
+            raise self._invalid_exc_type(value).with_field_and_value(self, value)
         if not isinstance(v, self._type):
             v = v.decode('ascii')
         self.validate(v)
@@ -417,15 +424,15 @@ class DottedName(_StrippedNativeStringLine):
         """
         super(DottedName, self)._validate(value)
         if not _isdotted(value):
-            raise InvalidDottedName(value)
+            raise InvalidDottedName(value).with_field_and_value(self, value)
         dots = value.count(".")
         if dots < self.min_dots:
             raise InvalidDottedName(
                 "too few dots; %d required" % self.min_dots, value
-            )
+            ).with_field_and_value(self, value)
         if self.max_dots is not None and dots > self.max_dots:
             raise InvalidDottedName("too many dots; no more than %d allowed" %
-                                    self.max_dots, value)
+                                    self.max_dots, value).with_field_and_value(self, value)
 
 
 
@@ -445,7 +452,7 @@ class Id(_StrippedNativeStringLine):
         if _isdotted(value) and "." in value:
             return
 
-        raise InvalidId(value)
+        raise InvalidId(value).with_field_and_value(self, value)
 
 
 @implementer(IInterfaceField)
@@ -455,7 +462,11 @@ class InterfaceField(Field):
     def _validate(self, value):
         super(InterfaceField, self)._validate(value)
         if not IInterface.providedBy(value):
-            raise WrongType("An interface is required", value, self.__name__)
+            raise WrongType(
+                "An interface is required",
+                value,
+                self.__name__
+            ).with_field_and_value(self, value)
 
 
 def _validate_sequence(value_type, value, errors=None):
@@ -500,11 +511,11 @@ def _validate_sequence(value_type, value, errors=None):
     return errors
 
 
-def _validate_uniqueness(value):
+def _validate_uniqueness(self, value):
     temp_values = []
     for item in value:
         if item in temp_values:
-            raise NotUnique(item)
+            raise NotUnique(item).with_field_and_value(self, value)
 
         temp_values.append(item)
 
@@ -534,9 +545,13 @@ class AbstractCollection(MinMaxLen, Iterable):
         super(AbstractCollection, self)._validate(value)
         errors = _validate_sequence(self.value_type, value)
         if errors:
-            raise WrongContainedType(errors, self.__name__)
+            try:
+                raise WrongContainedType(errors, self.__name__).with_field_and_value(self, value)
+            finally:
+                # Break cycles
+                del errors
         if self.unique:
-            _validate_uniqueness(value)
+            _validate_uniqueness(self, value)
 
 
 @implementer(ITuple)
@@ -577,9 +592,8 @@ class FrozenSet(AbstractCollection):
 VALIDATED_VALUES = threading.local()
 
 
-def _validate_fields(schema, value, errors=None):
-    if errors is None:
-        errors = []
+def _validate_fields(schema, value):
+    errors = {}
     # Interface can be used as schema property for Object fields that plan to
     # hold values of any type.
     # Because Interface does not include any Attribute, it is obviously not
@@ -599,22 +613,24 @@ def _validate_fields(schema, value, errors=None):
     # that supports attribute assignment.)
     try:
         for name in schema.names(all=True):
-            if not IMethod.providedBy(schema[name]):
-                try:
-                    attribute = schema[name]
-                    if IChoice.providedBy(attribute):
-                        # Choice must be bound before validation otherwise
-                        # IContextSourceBinder is not iterable in validation
-                        bound = attribute.bind(value)
-                        bound.validate(getattr(value, name))
-                    elif IField.providedBy(attribute):
-                        # validate attributes that are fields
-                        attribute.validate(getattr(value, name))
-                except ValidationError as error:
-                    errors.append(error)
-                except AttributeError as error:
-                    # property for the given name is not implemented
-                    errors.append(SchemaNotFullyImplemented(error))
+            attribute = schema[name]
+            if IMethod.providedBy(attribute):
+                continue # pragma: no cover
+
+            try:
+                if IChoice.providedBy(attribute):
+                    # Choice must be bound before validation otherwise
+                    # IContextSourceBinder is not iterable in validation
+                    bound = attribute.bind(value)
+                    bound.validate(getattr(value, name))
+                elif IField.providedBy(attribute):
+                    # validate attributes that are fields
+                    attribute.validate(getattr(value, name))
+            except ValidationError as error:
+                errors[name] = error
+            except AttributeError as error:
+                # property for the given name is not implemented
+                errors[name] = SchemaNotFullyImplemented(error)
     finally:
         del VALIDATED_VALUES.__dict__[id(value)]
     return errors
@@ -650,11 +666,11 @@ class Object(Field):
             raise SchemaNotProvided
 
         # check the value against schema
-        errors = _validate_fields(self.schema, value)
-
+        schema_error_dict = _validate_fields(self.schema, value)
+        invariant_errors = []
         if self.validate_invariants:
             try:
-                self.schema.validateInvariants(value, errors)
+                self.schema.validateInvariants(value, invariant_errors)
             except Invalid:
                 # validateInvariants raises a wrapper error around
                 # all the errors it got if it got errors, in addition
@@ -662,8 +678,22 @@ class Object(Field):
                 # that, we raise our own error.
                 pass
 
-        if errors:
-            raise WrongContainedType(errors, self.__name__)
+        if schema_error_dict or invariant_errors:
+            errors = list(schema_error_dict.values()) + invariant_errors
+            exception = SchemaNotCorrectlyImplemented(
+                errors,
+                self.__name__
+            ).with_field_and_value(self, value)
+            exception.schema_errors = schema_error_dict
+            exception.invariant_errors = invariant_errors
+            try:
+                raise exception
+            finally:
+                # Break cycles
+                del exception
+                del invariant_errors
+                del schema_error_dict
+                del errors
 
     def set(self, object, value):
         # Announce that we're going to assign the value to the object.
@@ -707,17 +737,17 @@ class Dict(MinMaxLen, Iterable):
     def _validate(self, value):
         super(Dict, self)._validate(value)
         errors = []
-        try:
-            if self.value_type:
-                errors = _validate_sequence(self.value_type, value.values(),
-                                            errors)
-            errors = _validate_sequence(self.key_type, value, errors)
+        if self.value_type:
+            errors = _validate_sequence(self.value_type, value.values(),
+                                        errors)
+        errors = _validate_sequence(self.key_type, value, errors)
 
-            if errors:
-                raise WrongContainedType(errors, self.__name__)
-
-        finally:
-            errors = None
+        if errors:
+            try:
+                raise WrongContainedType(errors, self.__name__).with_field_and_value(self, value)
+            finally:
+                # Break cycles
+                del errors
 
     def bind(self, object):
         """See zope.schema._bootstrapinterfaces.IField."""

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -185,6 +185,10 @@ class ASCIILine(ASCII):
         return '\n' not in value
 
 
+class InvalidFloatLiteral(ValueError, ValidationError):
+    """Raised by Float fields."""
+
+
 @implementer(IFloat, IFromUnicode)
 class Float(Orderable, Field):
     __doc__ = IFloat.__doc__
@@ -196,7 +200,10 @@ class Float(Orderable, Field):
     def fromUnicode(self, uc):
         """ See IFromUnicode.
         """
-        v = float(uc)
+        try:
+            v = float(uc)
+        except ValueError as v:
+            raise InvalidFloatLiteral(*v.args).with_field_and_value(self, uc)
         self.validate(v)
         return v
 

--- a/src/zope/schema/_schema.py
+++ b/src/zope/schema/_schema.py
@@ -80,8 +80,9 @@ def getSchemaValidationErrors(schema, object):
             value = getattr(object, name)
         except AttributeError as error:
             # property for the given name is not implemented
-            errors.append((
-                name, zope.schema.interfaces.SchemaNotFullyImplemented(error)))
+            error = zope.schema.interfaces.SchemaNotFullyImplemented(error)
+            error = error.with_field_and_value(attribute, None)
+            errors.append((name, error))
         else:
             try:
                 attribute.bind(object).validate(value)

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -56,6 +56,18 @@ class WrongContainedType(ValidationError):
     __doc__ = _("""Wrong contained type""")
 
 
+class SchemaNotCorrectlyImplemented(WrongContainedType):
+    __doc__ = _("""An object failed schema or invariant validation.""")
+
+    #: A dictionary mapping failed attribute names of the
+    #: *value* to the underlying exception
+    schema_errors = None
+
+    #: A list of exceptions from validating the invariants
+    #: of the schema.
+    invariant_errors = ()
+
+
 class NotUnique(ValidationError):
     __doc__ = _("""One or more entries of sequence are not unique.""")
 

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -414,7 +414,13 @@ class ContainerTests(unittest.TestCase):
     def test__validate_not_collection_not_iterable(self):
         from zope.schema._bootstrapinterfaces import NotAContainer
         cont = self._makeOne()
-        self.assertRaises(NotAContainer, cont._validate, object())
+        bad_value = object()
+        with self.assertRaises(NotAContainer) as exc:
+            cont._validate(bad_value)
+
+        not_cont = exc.exception
+        self.assertIs(not_cont.field, cont)
+        self.assertIs(not_cont.value, bad_value)
 
     def test__validate_collection_but_not_iterable(self):
         cont = self._makeOne()
@@ -453,7 +459,13 @@ class IterableTests(ContainerTests):
         class Dummy(object):
             def __contains__(self, item):
                 raise AssertionError("Not called")
-        self.assertRaises(NotAnIterator, itr._validate, Dummy())
+        dummy = Dummy()
+        with self.assertRaises(NotAnIterator) as exc:
+            itr._validate(dummy)
+
+        not_it = exc.exception
+        self.assertIs(not_it.field, itr)
+        self.assertIs(not_it.value, dummy)
 
 
 class OrderableTests(unittest.TestCase):

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -1887,7 +1887,14 @@ class ObjectTests(unittest.TestCase):
         from zope.schema._bootstrapfields import Text
         schema = self._makeSchema(foo=Text(), bar=Text())
         objf = self._makeOne(schema)
-        self.assertRaises(SchemaNotProvided, objf.validate, object())
+        bad_value = object()
+        with self.assertRaises(SchemaNotProvided) as exc:
+            objf.validate(bad_value)
+
+        not_provided = exc.exception
+        self.assertIs(not_provided.field, objf)
+        self.assertIs(not_provided.value, bad_value)
+        self.assertEqual(not_provided.args, (schema, bad_value), )
 
     def test__validate_w_value_providing_schema_but_missing_fields(self):
         from zope.interface import implementer

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -422,7 +422,7 @@ class DecimalTests(OrderableMissingValueMixin,
         self.assertEqual(too_big.value, decimal.Decimal("20.02"))
 
     def test_fromUnicode_miss(self):
-
+        from zope.schema.interfaces import ValidationError
         flt = self._makeOne()
         self.assertRaises(ValueError, flt.fromUnicode, u'')
         self.assertRaises(ValueError, flt.fromUnicode, u'abc')
@@ -432,6 +432,7 @@ class DecimalTests(OrderableMissingValueMixin,
         value_error = exc.exception
         self.assertIs(value_error.field, flt)
         self.assertEqual(value_error.value, u'1.4G')
+        self.assertIsInstance(value_error, ValidationError)
 
     def test_fromUnicode_hit(self):
         from decimal import Decimal
@@ -1921,8 +1922,11 @@ class ObjectTests(unittest.TestCase):
             ['bar', 'foo']
         )
         for name in ('foo', 'bar'):
-            self.assertIsInstance(wct.schema_errors[name],
+            error = wct.schema_errors[name]
+            self.assertIsInstance(error,
                                   SchemaNotFullyImplemented)
+            self.assertEqual(schema[name], error.field)
+            self.assertIsNone(error.value)
 
         # The legacy arg[0] errors list
         errors = self._getErrors(objf.validate, Broken())

--- a/src/zope/schema/tests/test_schema.py
+++ b/src/zope/schema/tests/test_schema.py
@@ -171,6 +171,9 @@ class Test_getValidationErrors(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0][0], 'must')
         self.assertEqual(errors[0][1].__class__, SchemaNotFullyImplemented)
+        self.assertIsNone(errors[0][1].value)
+        self.assertEqual(IWithRequired['must'],
+                         errors[0][1].field)
 
     def test_schema_with_invariant_errors(self):
         from zope.interface import Interface
@@ -246,6 +249,9 @@ class Test_getSchemaValidationErrors(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0][0], 'must')
         self.assertEqual(errors[0][1].__class__, SchemaNotFullyImplemented)
+        self.assertIsNone(errors[0][1].value)
+        self.assertEqual(IWithRequired['must'],
+                         errors[0][1].field)
 
     def test_schema_with_invalid_field(self):
         from zope.interface import Interface

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,10 @@ envlist =
 
 [testenv]
 deps =
-    .[test]
+    .[test,docs]
 commands =
     zope-testrunner --test-path=src
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 
 [testenv:coverage]
 usedevelop = true
@@ -24,7 +25,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python2.7
+    python3.6
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
All of them have a ``field`` and ``value`` now.

For Object fields, introduce a new exception (extending the old exception) to allow distinguishing which fields threw which error and which errors are general validation errors.

Fixes #16 