### PR TITLE
Include a field's interface in equality and hashing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,16 @@
   compatibility problem. See `issue 36
   <https://github.com/zopefoundation/zope.schema/issues/36>`_.
 
+- ``Field`` instances are only equal when their ``.interface`` is
+  equal. In practice, this means that two otherwise identical fields
+  of separate schemas are not equal, do not hash the same, and can
+  both be members of the same ``dict`` or ``set``. Prior to this
+  release, when hashing was identity based but only worked on Python
+  2, that was the typical behaviour. (Field objects that are *not*
+  members of a schema continue to compare and hash equal if they have
+  the same attributes and interfaces.) See `issue 40
+  <https://github.com/zopefoundation/zope.schema/issues/40>`_.
+
 - Orderable fields, including ``Int``, ``Float``, ``Decimal``,
   ``Timedelta``, ``Date`` and ``Time``, can now have a
   ``missing_value`` without needing to specify concrete ``min`` and

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -119,7 +119,7 @@ class Field(Attribute):
     default = DefaultProperty('default')
 
     # These were declared as slots in zope.interface, we override them here to
-    # get rid of the dedcriptors so they don't break .bind()
+    # get rid of the descriptors so they don't break .bind()
     __name__ = None
     interface = None
     _Element__tagged_values = None
@@ -206,20 +206,23 @@ class Field(Attribute):
             names.update(getFields(interface))
 
         # order will be different always, don't compare it
-        if 'order' in names:
-            del names['order']
+        names.pop('order', None)
         return names
 
     def __hash__(self):
         # Equal objects should have equal hashes;
         # equal hashes does not imply equal objects.
-        value = (type(self),) + tuple(self.__get_property_names_to_compare())
+        value = (type(self), self.interface) + tuple(self.__get_property_names_to_compare())
         return hash(value)
 
     def __eq__(self, other):
-        # should be the same type
-        if type(self) != type(other):
+        # should be the same type and in the same interface (or no interface at all)
+        if self is other:
+            return True
+
+        if type(self) != type(other) or self.interface != other.interface:
             return False
+
 
         # should have the same properties
         names = self.__get_property_names_to_compare()


### PR DESCRIPTION
Fixes #40 

There will be test conflicts with #50. Once either of them is merged I will fix the test conflicts and expand the usage of the EqualityTestsMixin to cover the rest of the fields in the remaining PR.