### PR TITLE
Make SimpleVocabulary.fromItems() accept triples to assign titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,16 @@
 - Make ``Iterable`` and ``Container`` properly implement ``IIterable``
   and ``IContainer``, respectively.
 
+- Make ``SimpleVocabulary.fromItems`` accept triples to allow
+  specifying the title of terms. See `issue 18
+  <https://github.com/zopefoundation/zope.schema/issues/18>`_.
+
+- Make ``TreeVocabulary.fromDict`` only create
+  ``ITitledTokenizedTerms`` when a title is actually provided.
+
+- Make ``SimpleVocabulary`` and ``SimpleTerm`` have value-based
+  equality and hashing methods.
+
 4.5.0 (2017-07-10)
 ==================
 

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -705,16 +705,13 @@ class ChoiceTests(EqualityTestsMixin,
         from zope.schema._field import Choice
         return Choice
 
-    from zope.schema.vocabulary import SimpleVocabulary
-    # SimpleVocabulary uses identity semantics for equality
-    _default_vocabulary = SimpleVocabulary.fromValues([1, 2, 3])
-
     def _makeOneFromClass(self, cls, *args, **kwargs):
         if (not args
             and 'vocabulary' not in kwargs
             and 'values' not in kwargs
             and 'source' not in kwargs):
-            kwargs['vocabulary'] = self._default_vocabulary
+            from zope.schema.vocabulary import SimpleVocabulary
+            kwargs['vocabulary'] = SimpleVocabulary.fromValues([1, 2, 3])
         return super(ChoiceTests, self)._makeOneFromClass(cls, *args, **kwargs)
 
     def _getTargetInterface(self):


### PR DESCRIPTION
Fixes #18

Some other vocabulary fixes while I was in there:

- Make TreeVocubalary.fromDict only actually assign titles when a  title is given. This makes it consistent with  `SimpleVocubalary.fromItems()` and make more sense IMO. There were no tests for this, so I added some.

- Give equality and hash methods to `SimpleTerm` and `SimpleVocubalary`.
  This was a confusing stumbling block in the implementation of #51.