### PR TITLE
Bind all fields of an Object's schema to the value being validated.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,12 @@
 - Make ``SimpleVocabulary`` and ``SimpleTerm`` have value-based
   equality and hashing methods.
 
+- All fields of the schema of an ``Object`` field are bound to the
+  top-level value being validated before attempting validation of
+  their particular attribute. Previously only ``IChoice`` fields were
+  bound. See `issue 17
+  <https://github.com/zopefoundation/zope.schema/issues/17>`_.
+
 4.5.0 (2017-07-10)
 ==================
 

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -187,10 +187,10 @@ class Field(Attribute):
     def constraint(self, value):
         return True
 
-    def bind(self, object):
+    def bind(self, context):
         clone = self.__class__.__new__(self.__class__)
         clone.__dict__.update(self.__dict__)
-        clone.context = object
+        clone.context = context
         return clone
 
     def validate(self, value):


### PR DESCRIPTION
Fixes #17 in a backwards compatible way.