### PR TITLE
Make Object a bootstrapfield.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,12 @@
 - Make ``SimpleVocabulary`` and ``SimpleTerm`` have value-based
   equality and hashing methods.
 
+- All fields of the schema of an ``Object`` field are bound to the
+  top-level value being validated before attempting validation of
+  their particular attribute. Previously only ``IChoice`` fields were
+  bound. See `issue 17
+  <https://github.com/zopefoundation/zope.schema/issues/17>`_.
+
 4.5.0 (2017-07-10)
 ==================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,97 +9,97 @@ better guide to the intended usage.
 Interfaces
 ==========
 
-.. autoclass:: zope.schema.interfaces.IField
-.. autoclass:: zope.schema.interfaces.IFromUnicode
-.. autoclass:: zope.schema.interfaces.IChoice
-.. autoclass:: zope.schema.interfaces.IContextAwareDefaultFactory
-.. autoclass:: zope.schema.interfaces.IOrderable
-.. autoclass:: zope.schema.interfaces.ILen
-.. autoclass:: zope.schema.interfaces.IMinMax
-.. autoclass:: zope.schema.interfaces.IMinMaxLen
-.. autoclass:: zope.schema.interfaces.IInterfaceField
-.. autoclass:: zope.schema.interfaces.IBool
-.. autoclass:: zope.schema.interfaces.IObject
-.. autoclass:: zope.schema.interfaces.IDict
+.. autointerface:: zope.schema.interfaces.IField
+.. autointerface:: zope.schema.interfaces.IFromUnicode
+.. autointerface:: zope.schema.interfaces.IChoice
+.. autointerface:: zope.schema.interfaces.IContextAwareDefaultFactory
+.. autointerface:: zope.schema.interfaces.IOrderable
+.. autointerface:: zope.schema.interfaces.ILen
+.. autointerface:: zope.schema.interfaces.IMinMax
+.. autointerface:: zope.schema.interfaces.IMinMaxLen
+.. autointerface:: zope.schema.interfaces.IInterfaceField
+.. autointerface:: zope.schema.interfaces.IBool
+.. autointerface:: zope.schema.interfaces.IObject
+.. autointerface:: zope.schema.interfaces.IDict
 
 Strings
 -------
 
-.. autoclass:: zope.schema.interfaces.IBytes
-.. autoclass:: zope.schema.interfaces.IBytesLine
-.. autoclass:: zope.schema.interfaces.IText
-.. autoclass:: zope.schema.interfaces.ITextLine
-.. autoclass:: zope.schema.interfaces.IASCII
-.. autoclass:: zope.schema.interfaces.IASCIILine
+.. autointerface:: zope.schema.interfaces.IBytes
+.. autointerface:: zope.schema.interfaces.IBytesLine
+.. autointerface:: zope.schema.interfaces.IText
+.. autointerface:: zope.schema.interfaces.ITextLine
+.. autointerface:: zope.schema.interfaces.IASCII
+.. autointerface:: zope.schema.interfaces.IASCIILine
 
-.. autoclass:: zope.schema.interfaces.IPassword
-.. autoclass:: zope.schema.interfaces.IURI
-.. autoclass:: zope.schema.interfaces.IId
-.. autoclass:: zope.schema.interfaces.IDottedName
+.. autointerface:: zope.schema.interfaces.IPassword
+.. autointerface:: zope.schema.interfaces.IURI
+.. autointerface:: zope.schema.interfaces.IId
+.. autointerface:: zope.schema.interfaces.IDottedName
 
 
 Numbers
 -------
 
-.. autoclass:: zope.schema.interfaces.INumber
-.. autoclass:: zope.schema.interfaces.IComplex
-.. autoclass:: zope.schema.interfaces.IReal
-.. autoclass:: zope.schema.interfaces.IRational
-.. autoclass:: zope.schema.interfaces.IIntegral
+.. autointerface:: zope.schema.interfaces.INumber
+.. autointerface:: zope.schema.interfaces.IComplex
+.. autointerface:: zope.schema.interfaces.IReal
+.. autointerface:: zope.schema.interfaces.IRational
+.. autointerface:: zope.schema.interfaces.IIntegral
 
-.. autoclass:: zope.schema.interfaces.IInt
-.. autoclass:: zope.schema.interfaces.IFloat
-.. autoclass:: zope.schema.interfaces.IDecimal
+.. autointerface:: zope.schema.interfaces.IInt
+.. autointerface:: zope.schema.interfaces.IFloat
+.. autointerface:: zope.schema.interfaces.IDecimal
 
 Date/Time
 ---------
 
-.. autoclass:: zope.schema.interfaces.IDatetime
-.. autoclass:: zope.schema.interfaces.IDate
-.. autoclass:: zope.schema.interfaces.ITimedelta
-.. autoclass:: zope.schema.interfaces.ITime
+.. autointerface:: zope.schema.interfaces.IDatetime
+.. autointerface:: zope.schema.interfaces.IDate
+.. autointerface:: zope.schema.interfaces.ITimedelta
+.. autointerface:: zope.schema.interfaces.ITime
 
 
 Collections
 -----------
-.. autoclass:: zope.schema.interfaces.IIterable
-.. autoclass:: zope.schema.interfaces.IContainer
-.. autoclass:: zope.schema.interfaces.ICollection
-.. autoclass:: zope.schema.interfaces.ISequence
-.. autoclass:: zope.schema.interfaces.IMutableSequence
-.. autoclass:: zope.schema.interfaces.IUnorderedCollection
-.. autoclass:: zope.schema.interfaces.IAbstractSet
-.. autoclass:: zope.schema.interfaces.IAbstractBag
+.. autointerface:: zope.schema.interfaces.IIterable
+.. autointerface:: zope.schema.interfaces.IContainer
+.. autointerface:: zope.schema.interfaces.ICollection
+.. autointerface:: zope.schema.interfaces.ISequence
+.. autointerface:: zope.schema.interfaces.IMutableSequence
+.. autointerface:: zope.schema.interfaces.IUnorderedCollection
+.. autointerface:: zope.schema.interfaces.IAbstractSet
+.. autointerface:: zope.schema.interfaces.IAbstractBag
 
-.. autoclass:: zope.schema.interfaces.ITuple
-.. autoclass:: zope.schema.interfaces.IList
-.. autoclass:: zope.schema.interfaces.ISet
-.. autoclass:: zope.schema.interfaces.IFrozenSet
+.. autointerface:: zope.schema.interfaces.ITuple
+.. autointerface:: zope.schema.interfaces.IList
+.. autointerface:: zope.schema.interfaces.ISet
+.. autointerface:: zope.schema.interfaces.IFrozenSet
 
 Events
 ------
 
-.. autoclass:: zope.schema.interfaces.IBeforeObjectAssignedEvent
-.. autoclass:: zope.schema.interfaces.IFieldEvent
-.. autoclass:: zope.schema.interfaces.IFieldUpdatedEvent
+.. autointerface:: zope.schema.interfaces.IBeforeObjectAssignedEvent
+.. autointerface:: zope.schema.interfaces.IFieldEvent
+.. autointerface:: zope.schema.interfaces.IFieldUpdatedEvent
 
 Vocabularies
 ------------
 
-.. autoclass:: zope.schema.interfaces.ITerm
-.. autoclass:: zope.schema.interfaces.ITokenizedTerm
-.. autoclass:: zope.schema.interfaces.ITitledTokenizedTerm
-.. autoclass:: zope.schema.interfaces.ISource
-.. autoclass:: zope.schema.interfaces.ISourceQueriables
-.. autoclass:: zope.schema.interfaces.IContextSourceBinder
-.. autoclass:: zope.schema.interfaces.IBaseVocabulary
-.. autoclass:: zope.schema.interfaces.IIterableVocabulary
-.. autoclass:: zope.schema.interfaces.IIterableSource
-.. autoclass:: zope.schema.interfaces.IVocabulary
-.. autoclass:: zope.schema.interfaces.IVocabularyTokenized
-.. autoclass:: zope.schema.interfaces.ITreeVocabulary
-.. autoclass:: zope.schema.interfaces.IVocabularyRegistry
-.. autoclass:: zope.schema.interfaces.IVocabularyFactory
+.. autointerface:: zope.schema.interfaces.ITerm
+.. autointerface:: zope.schema.interfaces.ITokenizedTerm
+.. autointerface:: zope.schema.interfaces.ITitledTokenizedTerm
+.. autointerface:: zope.schema.interfaces.ISource
+.. autointerface:: zope.schema.interfaces.ISourceQueriables
+.. autointerface:: zope.schema.interfaces.IContextSourceBinder
+.. autointerface:: zope.schema.interfaces.IBaseVocabulary
+.. autointerface:: zope.schema.interfaces.IIterableVocabulary
+.. autointerface:: zope.schema.interfaces.IIterableSource
+.. autointerface:: zope.schema.interfaces.IVocabulary
+.. autointerface:: zope.schema.interfaces.IVocabularyTokenized
+.. autointerface:: zope.schema.interfaces.ITreeVocabulary
+.. autointerface:: zope.schema.interfaces.IVocabularyRegistry
+.. autointerface:: zope.schema.interfaces.IVocabularyFactory
 
 Exceptions
 ----------

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -18,24 +18,36 @@ __docformat__ = 'restructuredtext'
 import decimal
 import fractions
 import numbers
+import threading
 from math import isinf
 
 from zope.interface import Attribute
+from zope.interface import Invalid
+from zope.interface import Interface
 from zope.interface import providedBy
 from zope.interface import implementer
+from zope.interface.interfaces import IInterface
+from zope.interface.interfaces import IMethod
 
-from zope.schema._bootstrapinterfaces import ValidationError
+from zope.event import notify
+
 from zope.schema._bootstrapinterfaces import ConstraintNotSatisfied
+from zope.schema._bootstrapinterfaces import IBeforeObjectAssignedEvent
 from zope.schema._bootstrapinterfaces import IContextAwareDefaultFactory
 from zope.schema._bootstrapinterfaces import IFromUnicode
+from zope.schema._bootstrapinterfaces import IValidatable
 from zope.schema._bootstrapinterfaces import NotAContainer
 from zope.schema._bootstrapinterfaces import NotAnIterator
 from zope.schema._bootstrapinterfaces import RequiredMissing
+from zope.schema._bootstrapinterfaces import SchemaNotCorrectlyImplemented
+from zope.schema._bootstrapinterfaces import SchemaNotFullyImplemented
+from zope.schema._bootstrapinterfaces import SchemaNotProvided
 from zope.schema._bootstrapinterfaces import StopValidation
 from zope.schema._bootstrapinterfaces import TooBig
 from zope.schema._bootstrapinterfaces import TooLong
 from zope.schema._bootstrapinterfaces import TooShort
 from zope.schema._bootstrapinterfaces import TooSmall
+from zope.schema._bootstrapinterfaces import ValidationError
 from zope.schema._bootstrapinterfaces import WrongType
 
 from zope.schema._compat import text_type
@@ -655,3 +667,167 @@ class Int(Integral):
     """
     _type = integer_types
     _unicode_converters = (int,)
+
+
+VALIDATED_VALUES = threading.local()
+
+def _validate_fields(schema, value):
+    errors = {}
+    # Interface can be used as schema property for Object fields that plan to
+    # hold values of any type.
+    # Because Interface does not include any Attribute, it is obviously not
+    # worth looping on its methods and filter them all out.
+    if schema is Interface:
+        return errors
+    # if `value` is part of a cyclic graph, we need to break the cycle to avoid
+    # infinite recursion. Collect validated objects in a thread local dict by
+    # it's python represenation. A previous version was setting a volatile
+    # attribute which didn't work with security proxy
+    if id(value) in VALIDATED_VALUES.__dict__:
+        return errors
+    VALIDATED_VALUES.__dict__[id(value)] = True
+    # (If we have gotten here, we know that `value` provides an interface
+    # other than zope.interface.Interface;
+    # iow, we can rely on the fact that it is an instance
+    # that supports attribute assignment.)
+
+    try:
+        for name in schema.names(all=True):
+            attribute = schema[name]
+            if IMethod.providedBy(attribute):
+                continue # pragma: no cover
+
+            try:
+                if IValidatable.providedBy(attribute):
+                    # validate attributes that are fields
+                    attribute.validate(getattr(value, name))
+                # XXX: We're not even checking the existence of non-IField
+                # Attribute objects.
+            except ValidationError as error:
+                errors[name] = error
+            except AttributeError as error:
+                # property for the given name is not implemented
+                errors[name] = SchemaNotFullyImplemented(error).with_field_and_value(attribute, None)
+    finally:
+        del VALIDATED_VALUES.__dict__[id(value)]
+    return errors
+
+
+class _BoundSchema(object):
+    """
+    This class proxies a schema to get its fields bound to a context.
+    """
+
+    __slots__ = ('schema', 'context')
+
+    def __new__(cls, schema, context):
+        # Only proxy if we really need to.
+        if schema is Interface or context is None:
+            return schema
+        return object.__new__(cls)
+
+    def __init__(self, schema, context):
+        self.schema = schema
+        self.context = context
+
+    def __getitem__(self, name):
+        # Indexing this item will bind fields,
+        # if possible
+        attr = self.schema[name]
+        try:
+            return attr.bind(self.context)
+        except AttributeError:
+            return attr
+
+    # but let all the rest slip to schema
+    def __getattr__(self, name):
+        return getattr(self.schema, name)
+
+
+class Object(Field):
+    """
+    Implementation of :class:`zope.schema.interfaces.IObject`.
+    """
+    schema = None
+
+    def __init__(self, schema=_NotGiven, **kw):
+        """
+        Object(schema=<Not Given>, *, validate_invariants=True, **kwargs)
+
+        Create an `~.IObject` field. The keyword arguments are as for `~.Field`.
+
+        .. versionchanged:: 4.6.0
+           Add the keyword argument *validate_invariants*. When true (the default),
+           the schema's ``validateInvariants`` method will be invoked to check
+           the ``@invariant`` properties of the schema.
+        .. versionchanged:: 4.6.0
+           The *schema* argument can be ommitted in a subclass
+           that specifies a ``schema`` attribute.
+        """
+        if schema is _NotGiven:
+            schema = self.schema
+
+        if not IInterface.providedBy(schema):
+            raise WrongType
+
+        self.schema = schema
+        self.validate_invariants = kw.pop('validate_invariants', True)
+        super(Object, self).__init__(**kw)
+
+    def _validate(self, value):
+        super(Object, self)._validate(value)
+
+        # schema has to be provided by value
+        if not self.schema.providedBy(value):
+            raise SchemaNotProvided(self.schema, value).with_field_and_value(self, value)
+
+        # check the value against schema
+        schema_error_dict = _validate_fields(_BoundSchema(self.schema, value), value)
+        invariant_errors = []
+        if self.validate_invariants:
+            try:
+                self.schema.validateInvariants(value, invariant_errors)
+            except Invalid:
+                # validateInvariants raises a wrapper error around
+                # all the errors it got if it got errors, in addition
+                # to appending them to the errors list. We don't want
+                # that, we raise our own error.
+                pass
+
+        if schema_error_dict or invariant_errors:
+            errors = list(schema_error_dict.values()) + invariant_errors
+            exception = SchemaNotCorrectlyImplemented(
+                errors,
+                self.__name__
+            ).with_field_and_value(self, value)
+            exception.schema_errors = schema_error_dict
+            exception.invariant_errors = invariant_errors
+            try:
+                raise exception
+            finally:
+                # Break cycles
+                del exception
+                del invariant_errors
+                del schema_error_dict
+                del errors
+
+    def set(self, object, value):
+        # Announce that we're going to assign the value to the object.
+        # Motivation: Widgets typically like to take care of policy-specific
+        # actions, like establishing location.
+        event = BeforeObjectAssignedEvent(value, self.__name__, object)
+        notify(event)
+        # The event subscribers are allowed to replace the object, thus we need
+        # to replace our previous value.
+        value = event.object
+        super(Object, self).set(object, value)
+
+
+@implementer(IBeforeObjectAssignedEvent)
+class BeforeObjectAssignedEvent(object):
+    """An object is going to be assigned to an attribute on another object."""
+
+    def __init__(self, object, name, context):
+        self.object = object
+        self.name = name
+        self.context = context

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -187,10 +187,10 @@ class Field(Attribute):
     def constraint(self, value):
         return True
 
-    def bind(self, object):
+    def bind(self, context):
         clone = self.__class__.__new__(self.__class__)
         clone.__dict__.update(self.__dict__)
-        clone.context = object
+        clone.context = context
         return clone
 
     def validate(self, value):

--- a/src/zope/schema/_bootstrapinterfaces.py
+++ b/src/zope/schema/_bootstrapinterfaces.py
@@ -16,6 +16,7 @@
 from functools import total_ordering
 
 import zope.interface
+from zope.interface import Attribute
 
 from zope.schema._messageid import _
 
@@ -108,6 +109,31 @@ class NotAnIterator(ValidationError):
     __doc__ = _("""Not an iterator""")
 
 
+
+class WrongContainedType(ValidationError):
+    __doc__ = _("""Wrong contained type""")
+
+
+class SchemaNotCorrectlyImplemented(WrongContainedType):
+    __doc__ = _("""An object failed schema or invariant validation.""")
+
+    #: A dictionary mapping failed attribute names of the
+    #: *value* to the underlying exception
+    schema_errors = None
+
+    #: A list of exceptions from validating the invariants
+    #: of the schema.
+    invariant_errors = ()
+
+
+class SchemaNotFullyImplemented(ValidationError):
+    __doc__ = _("""Schema not fully implemented""")
+
+
+class SchemaNotProvided(ValidationError):
+    __doc__ = _("""Schema not provided""")
+
+
 class IFromUnicode(zope.interface.Interface):
     """Parse a unicode string to a value
 
@@ -131,6 +157,35 @@ class IContextAwareDefaultFactory(zope.interface.Interface):
     def __call__(context):
         """Returns a default value for the field."""
 
+
+class IBeforeObjectAssignedEvent(zope.interface.Interface):
+    """An object is going to be assigned to an attribute on another object.
+
+    Subscribers to this event can change the object on this event to change
+    what object is going to be assigned. This is useful, e.g. for wrapping
+    or replacing objects before they get assigned to conform to application
+    policy.
+    """
+
+    object = Attribute("The object that is going to be assigned.")
+
+    name = Attribute("The name of the attribute under which the object "
+                     "will be assigned.")
+
+    context = Attribute("The context object where the object will be "
+                        "assigned to.")
+
+
+class IValidatable(zope.interface.Interface):
+    # Internal interface, the basis for IField, but used to prevent
+    # import recursion
+    def validate(value):
+        """Validate that the given value is a valid field value.
+
+        Returns nothing but raises an error if the value is invalid.
+        It checks everything specific to a Field and also checks
+        with the additional constraint.
+        """
 
 class NO_VALUE(object):
     def __repr__(self): # pragma: no cover

--- a/src/zope/schema/_field.py
+++ b/src/zope/schema/_field.py
@@ -27,20 +27,16 @@ from datetime import timedelta
 from datetime import time
 import decimal
 import re
-import threading
 
-from zope.event import notify
+
 from zope.interface import classImplements
 from zope.interface import implementer
-from zope.interface import Interface
-from zope.interface import Invalid
 from zope.interface.interfaces import IInterface
-from zope.interface.interfaces import IMethod
+
 
 from zope.schema.interfaces import IASCII
 from zope.schema.interfaces import IASCIILine
 from zope.schema.interfaces import IBaseVocabulary
-from zope.schema.interfaces import IBeforeObjectAssignedEvent
 from zope.schema.interfaces import IBool
 from zope.schema.interfaces import IBytes
 from zope.schema.interfaces import IBytesLine
@@ -89,9 +85,6 @@ from zope.schema.interfaces import InvalidValue
 from zope.schema.interfaces import WrongType
 from zope.schema.interfaces import WrongContainedType
 from zope.schema.interfaces import NotUnique
-from zope.schema.interfaces import SchemaNotProvided
-from zope.schema.interfaces import SchemaNotCorrectlyImplemented
-from zope.schema.interfaces import SchemaNotFullyImplemented
 from zope.schema.interfaces import InvalidURI
 from zope.schema.interfaces import InvalidId
 from zope.schema.interfaces import InvalidDottedName
@@ -113,6 +106,7 @@ from zope.schema._bootstrapfields import Rational
 from zope.schema._bootstrapfields import Real
 from zope.schema._bootstrapfields import MinMaxLen
 from zope.schema._bootstrapfields import _NotGiven
+from zope.schema._bootstrapfields import Object
 from zope.schema.fieldproperty import FieldProperty
 from zope.schema.vocabulary import getVocabularyRegistry
 from zope.schema.vocabulary import VocabularyRegistryError
@@ -150,6 +144,8 @@ classImplements(Real, IReal)
 classImplements(Rational, IRational)
 classImplements(Integral, IIntegral)
 classImplements(Int, IInt)
+
+classImplements(Object, IObject)
 
 
 
@@ -702,169 +698,6 @@ class Set(_AbstractSet):
 @implementer(IFrozenSet)
 class FrozenSet(_AbstractSet):
     _type = frozenset
-
-
-VALIDATED_VALUES = threading.local()
-
-
-def _validate_fields(schema, value):
-    errors = {}
-    # Interface can be used as schema property for Object fields that plan to
-    # hold values of any type.
-    # Because Interface does not include any Attribute, it is obviously not
-    # worth looping on its methods and filter them all out.
-    if schema is Interface:
-        return errors
-    # if `value` is part of a cyclic graph, we need to break the cycle to avoid
-    # infinite recursion. Collect validated objects in a thread local dict by
-    # it's python represenation. A previous version was setting a volatile
-    # attribute which didn't work with security proxy
-    if id(value) in VALIDATED_VALUES.__dict__:
-        return errors
-    VALIDATED_VALUES.__dict__[id(value)] = True
-    # (If we have gotten here, we know that `value` provides an interface
-    # other than zope.interface.Interface;
-    # iow, we can rely on the fact that it is an instance
-    # that supports attribute assignment.)
-    try:
-        for name in schema.names(all=True):
-            attribute = schema[name]
-            if IMethod.providedBy(attribute):
-                continue # pragma: no cover
-
-            try:
-                if IField.providedBy(attribute):
-                    # validate attributes that are fields
-                    attribute.validate(getattr(value, name))
-                # XXX: We're not even checking the existence of non-IField
-                # Attribute objects.
-            except ValidationError as error:
-                errors[name] = error
-            except AttributeError as error:
-                # property for the given name is not implemented
-                errors[name] = SchemaNotFullyImplemented(error).with_field_and_value(attribute, None)
-    finally:
-        del VALIDATED_VALUES.__dict__[id(value)]
-    return errors
-
-
-class _BoundSchema(object):
-    """
-    This class proxies a schema to get its fields bound to a context.
-    """
-
-    __slots__ = ('schema', 'context')
-
-    def __new__(cls, schema, context):
-        # Only proxy if we really need to.
-        if schema is Interface or context is None:
-            return schema
-        return object.__new__(cls)
-
-    def __init__(self, schema, context):
-        self.schema = schema
-        self.context = context
-
-    def __getitem__(self, name):
-        # Indexing this item will bind fields,
-        # if possible
-        attr = self.schema[name]
-        try:
-            return attr.bind(self.context)
-        except AttributeError:
-            return attr
-
-    # but let all the rest slip to schema
-    def __getattr__(self, name):
-        return getattr(self.schema, name)
-
-
-@implementer(IObject)
-class Object(Field):
-    __doc__ = IObject.__doc__
-    schema = None
-
-    def __init__(self, schema=_NotGiven, **kw):
-        """
-        Object(schema=<Not Given>, *, validate_invariants=True, **kwargs)
-
-        Create an `~.IObject` field. The keyword arguments are as for `~.Field`.
-
-        .. versionchanged:: 4.6.0
-           Add the keyword argument *validate_invariants*. When true (the default),
-           the schema's ``validateInvariants`` method will be invoked to check
-           the ``@invariant`` properties of the schema.
-        .. versionchanged:: 4.6.0
-           The *schema* argument can be ommitted in a subclass
-           that specifies a ``schema`` attribute.
-        """
-        if schema is _NotGiven:
-            schema = self.schema
-
-        if not IInterface.providedBy(schema):
-            raise WrongType
-
-        self.schema = schema
-        self.validate_invariants = kw.pop('validate_invariants', True)
-        super(Object, self).__init__(**kw)
-
-    def _validate(self, value):
-        super(Object, self)._validate(value)
-
-        # schema has to be provided by value
-        if not self.schema.providedBy(value):
-            raise SchemaNotProvided(self.schema, value).with_field_and_value(self, value)
-
-        # check the value against schema
-        schema_error_dict = _validate_fields(_BoundSchema(self.schema, value), value)
-        invariant_errors = []
-        if self.validate_invariants:
-            try:
-                self.schema.validateInvariants(value, invariant_errors)
-            except Invalid:
-                # validateInvariants raises a wrapper error around
-                # all the errors it got if it got errors, in addition
-                # to appending them to the errors list. We don't want
-                # that, we raise our own error.
-                pass
-
-        if schema_error_dict or invariant_errors:
-            errors = list(schema_error_dict.values()) + invariant_errors
-            exception = SchemaNotCorrectlyImplemented(
-                errors,
-                self.__name__
-            ).with_field_and_value(self, value)
-            exception.schema_errors = schema_error_dict
-            exception.invariant_errors = invariant_errors
-            try:
-                raise exception
-            finally:
-                # Break cycles
-                del exception
-                del invariant_errors
-                del schema_error_dict
-                del errors
-
-    def set(self, object, value):
-        # Announce that we're going to assign the value to the object.
-        # Motivation: Widgets typically like to take care of policy-specific
-        # actions, like establishing location.
-        event = BeforeObjectAssignedEvent(value, self.__name__, object)
-        notify(event)
-        # The event subscribers are allowed to replace the object, thus we need
-        # to replace our previous value.
-        value = event.object
-        super(Object, self).set(object, value)
-
-
-@implementer(IBeforeObjectAssignedEvent)
-class BeforeObjectAssignedEvent(object):
-    """An object is going to be assigned to an attribute on another object."""
-
-    def __init__(self, object, name, context):
-        self.object = object
-        self.name = name
-        self.context = context
 
 
 @implementer(IMapping)

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -15,12 +15,12 @@
 """
 __docformat__ = "reStructuredText"
 
-from zope.interface import Interface, Attribute
+from zope.interface import Interface
+from zope.interface import Attribute
+from zope.interface.interfaces import IInterface
 from zope.interface.common.mapping import IEnumerableMapping
 
 
-# Import from _bootstrapinterfaces only because other packages will expect
-# to find these interfaces here.
 from zope.schema._bootstrapfields import Field
 from zope.schema._bootstrapfields import Text
 from zope.schema._bootstrapfields import TextLine
@@ -31,6 +31,10 @@ from zope.schema._bootstrapfields import Rational
 from zope.schema._bootstrapfields import Real
 from zope.schema._bootstrapfields import Integral
 from zope.schema._bootstrapfields import Int
+from zope.schema._bootstrapfields import Object
+
+# Import from _bootstrapinterfaces only because other packages will expect
+# to find these interfaces here.
 from zope.schema._bootstrapinterfaces import StopValidation
 from zope.schema._bootstrapinterfaces import ValidationError
 from zope.schema._bootstrapinterfaces import IFromUnicode
@@ -44,45 +48,116 @@ from zope.schema._bootstrapinterfaces import TooBig
 from zope.schema._bootstrapinterfaces import TooLong
 from zope.schema._bootstrapinterfaces import TooShort
 from zope.schema._bootstrapinterfaces import InvalidValue
+from zope.schema._bootstrapinterfaces import WrongContainedType
+from zope.schema._bootstrapinterfaces import SchemaNotCorrectlyImplemented
+from zope.schema._bootstrapinterfaces import SchemaNotFullyImplemented
+from zope.schema._bootstrapinterfaces import SchemaNotProvided
+from zope.schema._bootstrapinterfaces import IBeforeObjectAssignedEvent
 from zope.schema._bootstrapinterfaces import IContextAwareDefaultFactory
+from zope.schema._bootstrapinterfaces import IValidatable
 
 from zope.schema._compat import PY3
 
 from zope.schema._messageid import _
 
+__all__ = [
+    # Exceptions
+    'ConstraintNotSatisfied',
+    'InvalidDottedName',
+    'InvalidId',
+    'InvalidURI',
+    'InvalidValue',
+    'NotAContainer',
+    'NotAnIterator',
+    'NotUnique',
+    'RequiredMissing',
+    'SchemaNotCorrectlyImplemented',
+    'SchemaNotFullyImplemented',
+    'SchemaNotProvided',
+    'StopValidation',
+    'TooBig',
+    'TooLong',
+    'TooShort',
+    'TooSmall',
+    'Unbound',
+    'ValidationError',
+    'WrongContainedType',
+    'WrongType',
 
-# pep 8 friendlyness
-StopValidation, ValidationError, IFromUnicode, RequiredMissing, WrongType
-ConstraintNotSatisfied, NotAContainer, NotAnIterator
-TooSmall, TooBig, TooLong, TooShort, InvalidValue, IContextAwareDefaultFactory
-
-
-class WrongContainedType(ValidationError):
-    __doc__ = _("""Wrong contained type""")
-
-
-class SchemaNotCorrectlyImplemented(WrongContainedType):
-    __doc__ = _("""An object failed schema or invariant validation.""")
-
-    #: A dictionary mapping failed attribute names of the
-    #: *value* to the underlying exception
-    schema_errors = None
-
-    #: A list of exceptions from validating the invariants
-    #: of the schema.
-    invariant_errors = ()
+    # Interfaces
+    'IASCII',
+    'IASCIILine',
+    'IAbstractBag',
+    'IAbstractSet',
+    'IBaseVocabulary',
+    'IBeforeObjectAssignedEvent',
+    'IBool',
+    'IBytes',
+    'IBytesLine',
+    'IChoice',
+    'ICollection',
+    'IComplex',
+    'IContainer',
+    'IContextAwareDefaultFactory',
+    'IContextSourceBinder',
+    'IDate',
+    'IDatetime',
+    'IDecimal',
+    'IDict',
+    'IDottedName',
+    'IField',
+    'IFieldEvent',
+    'IFieldUpdatedEvent',
+    'IFloat',
+    'IFromUnicode',
+    'IFrozenSet',
+    'IId',
+    'IInt',
+    'IIntegral',
+    'IInterfaceField',
+    'IIterable',
+    'IIterableSource',
+    'IIterableVocabulary',
+    'ILen',
+    'IList',
+    'IMapping',
+    'IMinMax',
+    'IMinMaxLen',
+    'IMutableMapping',
+    'IMutableSequence',
+    'INativeString',
+    'INativeStringLine',
+    'INumber',
+    'IObject',
+    'IOrderable',
+    'IPassword',
+    'IRational',
+    'IReal',
+    'ISequence',
+    'ISet',
+    'ISource',
+    'ISourceQueriables',
+    'ISourceText',
+    'ITerm',
+    'IText',
+    'ITextLine',
+    'ITime',
+    'ITimedelta',
+    'ITitledTokenizedTerm',
+    'ITokenizedTerm',
+    'ITreeVocabulary',
+    'ITuple',
+    'IURI',
+    'IUnorderedCollection',
+    'IVocabulary',
+    'IVocabularyFactory',
+    'IVocabularyRegistry',
+    'IVocabularyTokenized',
+]
 
 
 class NotUnique(ValidationError):
     __doc__ = _("""One or more entries of sequence are not unique.""")
-
-
-class SchemaNotFullyImplemented(ValidationError):
-    __doc__ = _("""Schema not fully implemented""")
-
-
-class SchemaNotProvided(ValidationError):
-    __doc__ = _("""Schema not provided""")
 
 
 class InvalidURI(ValidationError):
@@ -101,7 +176,7 @@ class Unbound(Exception):
     __doc__ = _("""The field is not bound.""")
 
 
-class IField(Interface):
+class IField(IValidatable):
     """Basic Schema Field Interface.
 
     Fields are used for Interface specifications.  They at least provide
@@ -639,14 +714,14 @@ class IChoice(IField):
 
 # Abstract
 
-
 class ICollection(IMinMaxLen, IIterable, IContainer):
     """Abstract interface containing a collection value.
 
     The Value must be iterable and may have a min_length/max_length.
     """
 
-    value_type = Field(
+    value_type = Object(
+        IField,
         title=_("Value Type"),
         description=_("Field value items must conform to the given type, "
                       "expressed via a Field."))
@@ -677,14 +752,14 @@ class IUnorderedCollection(ICollection):
 class IAbstractSet(IUnorderedCollection):
     """An unordered collection of unique values."""
 
-    unique = Attribute("This ICollection interface attribute must be True")
+    unique = Bool(description="This ICollection interface attribute must be True")
 
 
 class IAbstractBag(IUnorderedCollection):
     """An unordered collection of values, with no limitations on whether
     members are unique"""
 
-    unique = Attribute("This ICollection interface attribute must be False")
+    unique = Bool(description="This ICollection interface attribute must be False")
 
 
 # Concrete
@@ -720,34 +795,19 @@ class IObject(IField):
        Add the *validate_invariants* attribute.
     """
 
-    schema = Attribute(
-        "schema",
-        _("The Interface that defines the Fields comprising the Object.")
+    schema = Object(
+        IInterface,
+        description=_("The Interface that defines the Fields comprising the Object.")
     )
 
-    validate_invariants = Attribute(
-        "validate_invariants",
-        _("A boolean that says whether ``schema.validateInvariants`` "
-          "is called from ``self.validate()``. The default is true.")
+    validate_invariants = Bool(
+        title="validate_invariants",
+        description=_("A boolean that says whether ``schema.validateInvariants`` "
+                      "is called from ``self.validate()``. The default is true."),
+        default=True,
     )
 
 
-class IBeforeObjectAssignedEvent(Interface):
-    """An object is going to be assigned to an attribute on another object.
-
-    Subscribers to this event can change the object on this event to change
-    what object is going to be assigned. This is useful, e.g. for wrapping
-    or replacing objects before they get assigned to conform to application
-    policy.
-    """
-
-    object = Attribute("The object that is going to be assigned.")
-
-    name = Attribute("The name of the attribute under which the object "
-                     "will be assigned.")
-
-    context = Attribute("The context object where the object will be "
-                        "assigned to.")
 
 class IMapping(IMinMaxLen, IIterable, IContainer):
     """
@@ -757,15 +817,15 @@ class IMapping(IMinMaxLen, IIterable, IContainer):
     of restrictions for keys and values contained in the dict.
 
     """
-    key_type = Attribute(
-        "key_type",
-        _("Field keys must conform to the given type, expressed via a Field.")
+    key_type = Object(
+        IField,
+        description=_("Field keys must conform to the given type, expressed via a Field.")
     )
 
-    value_type = Attribute(
-        "value_type",
-        _("Field values must conform to the given type, expressed "
-          "via a Field.")
+    value_type = Object(
+        IField,
+        description=_("Field values must conform to the given type, expressed "
+                      "via a Field.")
     )
 
 
@@ -948,7 +1008,9 @@ class IVocabularyFactory(Interface):
 
 class IFieldEvent(Interface):
 
-    field = Attribute("The field that has been changed")
+    field = Object(
+        IField,
+        description="The field that has been changed")
 
     object = Attribute("The object containing the field")
 


### PR DESCRIPTION
And use it to define more attributes in interfaces.py

Switch from just repeating attribute names in interfaces.py to a real `__all__` attribute that linters can warn about (since I was moving classes around anyway this seemed like a good time).

Change ..autoclass:: in api.rst to ..autointerface:: so we get the actual member documentation and not lots of warnings about missing `__mro__`. (This is unrelated, I was just tired of the warnings.)

Currently based on #53 because that reduced the dependencies of _validate_fields.

Fixes #13