### PR TITLE
Add IFromBytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
  Changes
 =========
 
-4.7.1 (unreleased)
+4.8.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add the interface ``IFromBytes``, which is implemented by the
+  numeric and bytes fields, as well as ``URI``, ``DottedName``, and
+  ``Id``.
 
 
 4.7.0 (2018-09-11)

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -723,7 +723,11 @@ class Number(Orderable, Field):
 
     # On Python 2, native strings are byte strings, which is
     # what the converters expect, so we don't need to do any decoding.
-    fromBytes = fromUnicode if PY2 else lambda self, value: self.fromUnicode(value.decode('utf-8'))
+    if PY2: # pragma: no cover
+        fromBytes = fromUnicode
+    else:
+        def fromBytes(self, value):
+            return self.fromUnicode(value.decode('utf-8'))
 
 
 class Complex(Number):

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -568,7 +568,12 @@ class Password(TextLine):
 
 @implementer(IFromUnicode, IFromBytes)
 class Bool(Field):
-    """A field representing a Bool."""
+    """
+    A field representing a Bool.
+
+    .. versionchanged:: 4.8.0
+        Implement :class:`zope.schema.interfaces.IFromBytes`
+    """
 
     _type = bool
 

--- a/src/zope/schema/_bootstrapinterfaces.py
+++ b/src/zope/schema/_bootstrapinterfaces.py
@@ -282,8 +282,20 @@ class IFromUnicode(zope.interface.Interface):
     values.
     """
 
-    def fromUnicode(str):
+    def fromUnicode(value):
         """Convert a unicode string to a value.
+        """
+
+
+class IFromBytes(zope.interface.Interface):
+    """
+    Parse a byte string to a value.
+
+    If the string needs to be decoded, decoding is done using UTF-8.
+    """
+
+    def fromBytes(value):
+        """Convert a byte string to a value.
         """
 
 

--- a/src/zope/schema/_compat.py
+++ b/src/zope/schema/_compat.py
@@ -1,6 +1,7 @@
 import sys
 
 PY3 = sys.version_info[0] >= 3
+PY2 = not PY3
 
 if PY3:  # pragma: no cover
 

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -38,6 +38,7 @@ from zope.schema._bootstrapfields import TextLine
 from zope.schema._bootstrapinterfaces import ConstraintNotSatisfied
 from zope.schema._bootstrapinterfaces import IBeforeObjectAssignedEvent
 from zope.schema._bootstrapinterfaces import IContextAwareDefaultFactory
+from zope.schema._bootstrapinterfaces import IFromBytes
 from zope.schema._bootstrapinterfaces import IFromUnicode
 from zope.schema._bootstrapinterfaces import IValidatable
 from zope.schema._bootstrapinterfaces import InvalidValue
@@ -118,6 +119,7 @@ __all__ = [
     'IFieldEvent',
     'IFieldUpdatedEvent',
     'IFloat',
+    'IFromBytes',
     'IFromUnicode',
     'IFrozenSet',
     'IId',

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -24,6 +24,10 @@ class EqualityTestsMixin(object):
     def _getTargetInterface(self):
         raise NotImplementedError
 
+    def _getTargetInterfaces(self):
+        # Return the primary and any secondary interfaces
+        return [self._getTargetInterface()]
+
     def _makeOne(self, *args, **kwargs):
         return self._makeOneFromClass(self._getTargetClass(),
                                       *args,
@@ -36,14 +40,16 @@ class EqualityTestsMixin(object):
         from zope.interface.verify import verifyClass
         cls = self._getTargetClass()
         __traceback_info__ = cls
-        verifyClass(self._getTargetInterface(), cls)
+        for iface in self._getTargetInterfaces():
+            verifyClass(iface, cls)
         return verifyClass
 
     def test_instance_conforms_to_iface(self):
         from zope.interface.verify import verifyObject
         instance = self._makeOne()
         __traceback_info__ = instance
-        verifyObject(self._getTargetInterface(), instance)
+        for iface in self._getTargetInterfaces():
+            verifyObject(iface, instance)
         return verifyObject
 
     def test_is_hashable(self):
@@ -1075,13 +1081,17 @@ class NumberTests(EqualityTestsMixin,
 
     def test_class_conforms_to_iface(self):
         from zope.schema._bootstrapinterfaces import IFromUnicode
+        from zope.schema._bootstrapinterfaces import IFromBytes
         verifyClass = super(NumberTests, self).test_class_conforms_to_iface()
         verifyClass(IFromUnicode, self._getTargetClass())
+        verifyClass(IFromBytes, self._getTargetClass())
 
     def test_instance_conforms_to_iface(self):
         from zope.schema._bootstrapinterfaces import IFromUnicode
+        from zope.schema._bootstrapinterfaces import IFromBytes
         verifyObject = super(NumberTests, self).test_instance_conforms_to_iface()
         verifyObject(IFromUnicode, self._makeOne())
+        verifyObject(IFromBytes, self._makeOne())
 
 
 class ComplexTests(NumberTests):

--- a/src/zope/schema/tests/test__field.py
+++ b/src/zope/schema/tests/test__field.py
@@ -42,6 +42,11 @@ class BytesTests(EqualityTestsMixin,
         from zope.schema.interfaces import IBytes
         return IBytes
 
+    def _getTargetInterfaces(self):
+        from zope.schema.interfaces import IFromUnicode
+        from zope.schema.interfaces import IFromBytes
+        return [self._getTargetInterface(), IFromUnicode, IFromBytes]
+
     def test_validate_wrong_types(self):
         field = self._makeOne()
         self.assertAllRaiseWrongType(
@@ -84,10 +89,14 @@ class BytesTests(EqualityTestsMixin,
         self.assertRaises(UnicodeEncodeError, byt.fromUnicode, u'\x81')
 
     def test_fromUnicode_hit(self):
-
         byt = self._makeOne()
         self.assertEqual(byt.fromUnicode(u''), b'')
         self.assertEqual(byt.fromUnicode(u'DEADBEEF'), b'DEADBEEF')
+
+    def test_fromBytes(self):
+        field = self._makeOne()
+        self.assertEqual(field.fromBytes(b''), b'')
+        self.assertEqual(field.fromBytes(b'DEADBEEF'), b'DEADBEEF')
 
 
 class ASCIITests(EqualityTestsMixin,
@@ -150,6 +159,11 @@ class BytesLineTests(EqualityTestsMixin,
         from zope.schema.interfaces import IBytesLine
         return IBytesLine
 
+    def _getTargetInterfaces(self):
+        from zope.schema.interfaces import IFromUnicode
+        from zope.schema.interfaces import IFromBytes
+        return [self._getTargetInterface(), IFromUnicode, IFromBytes]
+
     def test_validate_wrong_types(self):
         field = self._makeOne()
         self.assertAllRaiseWrongType(
@@ -166,7 +180,6 @@ class BytesLineTests(EqualityTestsMixin,
             object())
 
     def test_validate_not_required(self):
-
         field = self._makeOne(required=False)
         field.validate(None)
         field.validate(b'')
@@ -183,13 +196,17 @@ class BytesLineTests(EqualityTestsMixin,
         self.assertRaises(RequiredMissing, field.validate, None)
 
     def test_constraint(self):
-
         field = self._makeOne()
         self.assertEqual(field.constraint(b''), True)
         self.assertEqual(field.constraint(b'abc'), True)
         self.assertEqual(field.constraint(b'abc'), True)
         self.assertEqual(field.constraint(b'\xab\xde'), True)
         self.assertEqual(field.constraint(b'abc\ndef'), False)
+
+    def test_fromBytes(self):
+        field = self._makeOne()
+        self.assertEqual(field.fromBytes(b''), b'')
+        self.assertEqual(field.fromBytes(b'DEADBEEF'), b'DEADBEEF')
 
 
 class ASCIILineTests(EqualityTestsMixin,
@@ -832,8 +849,12 @@ class URITests(EqualityTestsMixin,
         from zope.schema.interfaces import IURI
         return IURI
 
+    def _getTargetInterfaces(self):
+        from zope.schema.interfaces import IFromUnicode
+        from zope.schema.interfaces import IFromBytes
+        return [self._getTargetInterface(), IFromUnicode, IFromBytes]
+
     def test_validate_wrong_types(self):
-        from zope.schema.interfaces import WrongType
         from zope.schema._compat import non_native_string
         field = self._makeOne()
         self.assertAllRaiseWrongType(
@@ -904,6 +925,11 @@ class DottedNameTests(EqualityTestsMixin,
     def _getTargetInterface(self):
         from zope.schema.interfaces import IDottedName
         return IDottedName
+
+    def _getTargetInterfaces(self):
+        from zope.schema.interfaces import IFromUnicode
+        from zope.schema.interfaces import IFromBytes
+        return [self._getTargetInterface(), IFromUnicode, IFromBytes]
 
     def test_ctor_defaults(self):
         dotted = self._makeOne()
@@ -1018,8 +1044,12 @@ class IdTests(EqualityTestsMixin,
         from zope.schema.interfaces import IId
         return IId
 
+    def _getTargetInterfaces(self):
+        from zope.schema.interfaces import IFromUnicode
+        from zope.schema.interfaces import IFromBytes
+        return [self._getTargetInterface(), IFromUnicode, IFromBytes]
+
     def test_validate_wrong_types(self):
-        from zope.schema.interfaces import WrongType
         from zope.schema._compat import non_native_string
         field = self._makeOne()
         self.assertAllRaiseWrongType(
@@ -1459,8 +1489,6 @@ class SetTests(WrongTypeTestsMixin,
         self.assertTrue(self._makeOne().unique)
 
     def test_validate_wrong_types(self):
-        from zope.schema.interfaces import WrongType
-
         field = self._makeOne()
         self.assertAllRaiseWrongType(
             field,
@@ -1510,8 +1538,6 @@ class MappingTests(EqualityTestsMixin,
         self.assertRaises(ValueError, self._makeOne, value_type=object())
 
     def test_validate_wrong_types(self):
-        from zope.schema.interfaces import WrongType
-
         field = self._makeOne()
         self.assertAllRaiseWrongType(
             field,


### PR DESCRIPTION
As a counterpoint to IFromUnicode.

This is useful when you know the type of data you're dealing with, and conversions are either trivially non-lossy (or will fail anyway) or are not necessary.

The numeric fields as well as Bytes/Line and URI, DottedName and Id implement this, the last three because they are native string lines that want to accept bytes on Python 2 anyway.

On Python 2, lxml likes to produce byte strings "to save memory" even when parsing unicode and given proper XML encoding information, so this can be very helpful there.

This stems from https://github.com/NextThought/nti.externalization/issues/92