### PR TITLE
Fix passing ``None`` as the description to a field constructor.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
   numeric and bytes fields, as well as ``URI``, ``DottedName``, and
   ``Id``.
 
+- Fix passing ``None`` as the description to a field constructor. See
+  `issue 69 <https://github.com/zopefoundation/zope.schema/issues/69>`_.
 
 4.7.0 (2018-09-11)
 ==================

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -244,7 +244,9 @@ class Field(Attribute):
         # Fix leading whitespace that occurs when using multi-line
         # strings, but don't overwrite the original, we need to
         # preserve it (it could be a MessageID).
-        doc_description = '\n'.join(_DocStringHelpers.docstring_to_lines(description)[:-1])
+        doc_description = '\n'.join(
+            _DocStringHelpers.docstring_to_lines(description or u'')[:-1]
+        )
 
         if title:
             if doc_description:

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -486,6 +486,31 @@ class FieldTests(EqualityTestsMixin,
             """)
         )
 
+    def test_ctor_description_none(self):
+        # None values for description don't break the docs.
+        import textwrap
+
+        description = None
+
+        title = u'A title'
+
+        field = self._makeOne(title=title, description=description)
+
+        self.assertIs(field.title, title)
+        self.assertIs(field.description, description)
+
+        self.assertEqual(
+            field.getDoc(),
+            textwrap.dedent("""\
+            A title
+
+            :Implementation: :class:`zope.schema.Field`
+            :Read Only: False
+            :Required: True
+            :Default Value: None
+            """)
+        )
+
     def test_ctor_defaults(self):
 
         field = self._makeOne()


### PR DESCRIPTION
Fixes #69.

An alternate version of #70 with conflicts resolved and a test case.