### PR TITLE
Make DottedName accept leading underscores.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@
   present. Previously it could produce ReST that generated Sphinx
   warnings. See `issue 76 <https://github.com/zopefoundation/zope.schema/issues/76>`_.
 
+- Make ``DottedName`` accept leading underscores for each segment.
+
+- Add ``PythonIdentifier``, which accepts one segment of a dotted
+  name, e.g., a python variable or class.
+
 4.8.0 (2018-09-19)
 ==================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,7 @@ Strings
 .. autointerface:: zope.schema.interfaces.IPassword
 .. autointerface:: zope.schema.interfaces.IURI
 .. autointerface:: zope.schema.interfaces.IId
+.. autointerface:: zope.schema.interfaces.IPythonIdentifier
 .. autointerface:: zope.schema.interfaces.IDottedName
 
 
@@ -184,8 +185,6 @@ Field Implementations
 .. autoclass:: zope.schema.Datetime
    :no-show-inheritance:
 .. autoclass:: zope.schema.Dict
-.. autoclass:: zope.schema.DottedName
-   :no-show-inheritance:
 
 .. autoclass:: zope.schema.FrozenSet
    :no-show-inheritance:
@@ -204,8 +203,6 @@ Field Implementations
 .. autoclass:: zope.schema.Object
    :no-show-inheritance:
 .. autoclass:: zope.schema.Orderable
-.. autoclass:: zope.schema.Password
-   :no-show-inheritance:
 .. autoclass:: zope.schema.Set
 .. autoclass:: zope.schema.Sequence
 .. autoclass:: zope.schema.Time
@@ -235,6 +232,12 @@ Strings
 .. autoclass:: zope.schema.NativeString
    :no-show-inheritance:
 .. autoclass:: zope.schema.NativeStringLine
+   :no-show-inheritance:
+.. autoclass:: zope.schema.Password
+   :no-show-inheritance:
+.. autoclass:: zope.schema.DottedName
+   :no-show-inheritance:
+.. autoclass:: zope.schema.PythonIdentifier
    :no-show-inheritance:
 
 Numbers

--- a/src/zope/schema/__init__.py
+++ b/src/zope/schema/__init__.py
@@ -47,6 +47,7 @@ from zope.schema._field import Number
 from zope.schema._field import Object
 from zope.schema._field import Orderable
 from zope.schema._field import Password
+from zope.schema._field import PythonIdentifier
 from zope.schema._field import Rational
 from zope.schema._field import Real
 from zope.schema._field import Sequence
@@ -107,6 +108,7 @@ __all__ = [
     'Number',
     'Object',
     'Orderable',
+    'PythonIdentifier',
     'Password',
     'Rational',
     'Real',

--- a/src/zope/schema/interfaces.py
+++ b/src/zope/schema/interfaces.py
@@ -142,6 +142,7 @@ __all__ = [
     'IObject',
     'IOrderable',
     'IPassword',
+    'IPythonIdentifier',
     'IRational',
     'IReal',
     'ISequence',
@@ -707,6 +708,14 @@ class IDottedName(INativeStringLine):
         required=False,
         default=None
         )
+
+
+class IPythonIdentifier(INativeStringLine):
+    """
+    A single Python identifier, such as a  variable name.
+
+    .. versionadded:: 4.9.0
+    """
 
 
 class IChoice(IField):


### PR DESCRIPTION
Also add a `PythonIdentifier` class, and share the regex for an identifier between `DottedName` and `PythonIdentifier` so they are in sync.

This is to help with https://github.com/zopefoundation/zope.configuration/pull/29 and https://github.com/zopefoundation/zope.configuration/issues/28