### PR TITLE
Fixed a ReST error in getDoc() results when having "subfields"  with title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.9.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed a ReST error in getDoc() results when having "subfields" 
+  with titles. 
 
 
 4.9.2 (2018-10-11)

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -399,6 +399,7 @@ class Field(Attribute):
             if hasattr(field, 'getDoc'):
                 lines.append("")
                 lines.append(".. rubric:: " + rubric)
+                lines.append("")
                 lines.append(field.getDoc())
 
         return lines

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -415,13 +415,13 @@ class FieldTests(EqualityTestsMixin,
 
         # value_type and key_type are automatically picked up
         field.value_type = self._makeOne()
-        field.key_type = self._makeOne()
-        doc = field .getDoc()
+        # Make sure the formatting works also with fields that have a title
+        field.key_type = self._makeOne(title=u'Key Type')
+        doc = field.getDoc()
         self.assertIn('.. rubric:: Key Type', doc)
         self.assertIn('.. rubric:: Value Type', doc)
-
         self.assertEqual(
-            field.getDoc(),
+            doc,
             textwrap.dedent("""
             :Implementation: :class:`zope.schema.Field`
             :Read Only: True
@@ -431,6 +431,8 @@ class FieldTests(EqualityTestsMixin,
 
             .. rubric:: Key Type
 
+            Key Type
+
             :Implementation: :class:`zope.schema.Field`
             :Read Only: False
             :Required: True
@@ -438,6 +440,7 @@ class FieldTests(EqualityTestsMixin,
 
 
             .. rubric:: Value Type
+
 
             :Implementation: :class:`zope.schema.Field`
             :Read Only: False


### PR DESCRIPTION
…titles