### PR TITLE
Fixing #86 by normalizing unicode for IFromUnicode

### DIFF
--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -508,7 +508,6 @@ class Text(MinMaxLen, Field):
 
     def __init__(self,  *args, **kw):
         self.unicode_normalization = kw.pop('unicode_normalization', 'NFC')
-        self.unicode_normalization = unicode_normalization
         super(Text, self).__init__(*args, **kw)
 
     def fromUnicode(self, str):

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 ##############################################################################
 #
 # Copyright (c) 2002 Zope Foundation and Contributors.

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -20,6 +20,7 @@ import fractions
 import numbers
 import sys
 import threading
+import unicodedata
 from math import isinf
 
 from zope.interface import Attribute
@@ -505,7 +506,8 @@ class Text(MinMaxLen, Field):
     """A field containing text used for human discourse."""
     _type = text_type
 
-    def __init__(self, *args, **kw):
+    def __init__(self, suppress_unicode_normalization=_NotGiven, *args, **kw):
+        self.suppress_unicode_normalization = suppress_unicode_normalization
         super(Text, self).__init__(*args, **kw)
 
     def fromUnicode(self, str):
@@ -528,8 +530,12 @@ class Text(MinMaxLen, Field):
         Traceback (most recent call last):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
+        >>> [ unicodedata.name(c) for c in t.fromUnicode(unicodedata.normalize('NFD', 'ÄÖÜ'))]
+        ['LATIN CAPITAL LETTER A WITH DIAERESIS', 'LATIN CAPITAL LETTER O WITH DIAERESIS', 'LATIN CAPITAL LETTER U WITH DIAERESIS']
         """
         self.validate(str)
+        if self.suppress_unicode_normalization is _NotGiven:
+            str = unicodedata.normalize('NFC', str)
         return str
 
 

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -512,7 +512,6 @@ class Text(MinMaxLen, Field):
 
     def fromUnicode(self, value):
         """
-        >>> import unicodedata
         >>> from zope.schema.interfaces import WrongType
         >>> from zope.schema.interfaces import ConstraintNotSatisfied
         >>> from zope.schema import Text

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -532,14 +532,16 @@ class Text(MinMaxLen, Field):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
         """
-        if not PY2:
-            unicode = str
-        if isinstance(value, unicode):
+        try:
+            text_type = unicode
+        except NameError:
+            text_type = str
+        if isinstance(value, text_type):
             if self.unicode_normalization:
                 value = unicodedata.normalize(self.unicode_normalization, value)
         self.validate(value)
         return value
-        
+
 
 class TextLine(Text):
     """A text field with no newlines."""

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -532,10 +532,6 @@ class Text(MinMaxLen, Field):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
         """
-        try:
-            text_type = unicode
-        except NameError:
-            text_type = str
         if isinstance(value, text_type):
             if self.unicode_normalization:
                 value = unicodedata.normalize(self.unicode_normalization, value)

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 ##############################################################################
 #
 # Copyright (c) 2002 Zope Foundation and Contributors.
@@ -534,9 +532,9 @@ class Text(MinMaxLen, Field):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
         """
-        self.validate(str)
         if self.unicode_normalization:
             str = unicodedata.normalize(self.unicode_normalization, str)
+        self.validate(str)
         return str
 
 

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -514,6 +514,7 @@ class Text(MinMaxLen, Field):
 
     def fromUnicode(self, str):
         """
+        >>> import unicodedata
         >>> from zope.schema.interfaces import WrongType
         >>> from zope.schema.interfaces import ConstraintNotSatisfied
         >>> from zope.schema import Text

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -508,8 +508,8 @@ class Text(MinMaxLen, Field):
     """A field containing text used for human discourse."""
     _type = text_type
 
-    def __init__(self, suppress_unicode_normalization=_NotGiven, *args, **kw):
-        self.suppress_unicode_normalization = suppress_unicode_normalization
+    def __init__(self, unicode_normalization='NFC', *args, **kw):
+        self.unicode_normalization = unicode_normalization
         super(Text, self).__init__(*args, **kw)
 
     def fromUnicode(self, str):
@@ -533,12 +533,12 @@ class Text(MinMaxLen, Field):
         Traceback (most recent call last):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
-        >>> [ unicodedata.name(c) for c in t.fromUnicode(unicodedata.normalize('NFD', 'ÄÖÜ'))]
+        >>> [unicodedata.name(c) for c in t.fromUnicode(unicodedata.normalize('NFD', u'ÄÖÜ'))]
         ['LATIN CAPITAL LETTER A WITH DIAERESIS', 'LATIN CAPITAL LETTER O WITH DIAERESIS', 'LATIN CAPITAL LETTER U WITH DIAERESIS']
         """
         self.validate(str)
-        if self.suppress_unicode_normalization is _NotGiven:
-            str = unicodedata.normalize('NFC', str)
+        if self.unicode_normalization:
+            str = unicodedata.normalize(self.unicode_normalization, str)
         return str
 
 

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -533,8 +533,6 @@ class Text(MinMaxLen, Field):
         Traceback (most recent call last):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
-        >>> [unicodedata.name(c) for c in t.fromUnicode(unicodedata.normalize('NFD', u'ÄÖÜ'))]
-        ['LATIN CAPITAL LETTER A WITH DIAERESIS', 'LATIN CAPITAL LETTER O WITH DIAERESIS', 'LATIN CAPITAL LETTER U WITH DIAERESIS']
         """
         self.validate(str)
         if self.unicode_normalization:

--- a/src/zope/schema/_bootstrapfields.py
+++ b/src/zope/schema/_bootstrapfields.py
@@ -510,7 +510,7 @@ class Text(MinMaxLen, Field):
         self.unicode_normalization = kw.pop('unicode_normalization', 'NFC')
         super(Text, self).__init__(*args, **kw)
 
-    def fromUnicode(self, str):
+    def fromUnicode(self, value):
         """
         >>> import unicodedata
         >>> from zope.schema.interfaces import WrongType
@@ -532,11 +532,14 @@ class Text(MinMaxLen, Field):
         ...
         zope.schema._bootstrapinterfaces.ConstraintNotSatisfied: (u'foo spam', '')
         """
-        if self.unicode_normalization:
-            str = unicodedata.normalize(self.unicode_normalization, str)
-        self.validate(str)
-        return str
-
+        if not PY2:
+            unicode = str
+        if isinstance(value, unicode):
+            if self.unicode_normalization:
+                value = unicodedata.normalize(self.unicode_normalization, value)
+        self.validate(value)
+        return value
+        
 
 class TextLine(Text):
     """A text field with no newlines."""

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -966,7 +966,7 @@ class TextTests(EqualityTestsMixin,
         self.assertEqual(txt.fromUnicode(deadbeef), deadbeef)
 
     def test_normalization(self):
-        deadbeef = unicodedata.normalize('NFD', 'ÄÖÜ')
+        deadbeef = unicodedata.normalize('NFD', u'ÄÖÜ')
         txt = self._makeOne()
         self.assertEqual(
             [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],
@@ -976,7 +976,7 @@ class TextTests(EqualityTestsMixin,
                 'LATIN CAPITAL LETTER U WITH DIAERESIS',
             ]
         )
-        txt = self._makeOne(suppress_unicode_normalization=True)
+        txt = self._makeOne(unicode_normalization=None)
         self.assertEqual(
             [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],
             [

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 ##############################################################################
 #
 # Copyright (c) 2012 Zope Foundation and Contributors.

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -964,7 +964,7 @@ class TextTests(EqualityTestsMixin,
         self.assertEqual(txt.fromUnicode(deadbeef), deadbeef)
 
     def test_normalization(self):
-        deadbeef = unicodedata.normalize('NFD', str(b'\xc3\x84\xc3\x96\xc3\x9c', 'utf-8'))
+        deadbeef = unicodedata.normalize('NFD', b'\xc3\x84\xc3\x96\xc3\x9c'.decode('utf-8'))
         txt = self._makeOne()
         self.assertEqual(
             [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 ##############################################################################
 #
 # Copyright (c) 2012 Zope Foundation and Contributors.
@@ -966,7 +964,7 @@ class TextTests(EqualityTestsMixin,
         self.assertEqual(txt.fromUnicode(deadbeef), deadbeef)
 
     def test_normalization(self):
-        deadbeef = unicodedata.normalize('NFD', u'ÄÖÜ')
+        deadbeef = unicodedata.normalize('NFD', b'\xc3\x84\xc3\x96\xc3\x9c'.decode('utf-8'))
         txt = self._makeOne()
         self.assertEqual(
             [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import doctest
 import unittest
+import unicodedata
 
 # pylint:disable=protected-access,inherit-non-class,blacklisted-name
 
@@ -958,10 +959,34 @@ class TextTests(EqualityTestsMixin,
         self.assertRaisesWrongType(txt.fromUnicode, txt._type, deadbeef)
 
     def test_fromUnicode_hit(self):
-
         deadbeef = u'DEADBEEF'
         txt = self._makeOne()
         self.assertEqual(txt.fromUnicode(deadbeef), deadbeef)
+
+    def test_normalization(self):
+        deadbeef = unicodedata.normalize('NFD', 'ÄÖÜ')
+        txt = self._makeOne()
+        self.assertEqual(
+            [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],
+            [
+                'LATIN CAPITAL LETTER A WITH DIAERESIS',
+                'LATIN CAPITAL LETTER O WITH DIAERESIS',
+                'LATIN CAPITAL LETTER U WITH DIAERESIS',
+            ]
+        )
+        txt = self._makeOne(suppress_unicode_normalization=True)
+        self.assertEqual(
+            [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],
+            [
+                'LATIN CAPITAL LETTER A',
+                'COMBINING DIAERESIS',
+                'LATIN CAPITAL LETTER O',
+                'COMBINING DIAERESIS',
+                'LATIN CAPITAL LETTER U',
+                'COMBINING DIAERESIS',
+            ]
+        )
+
 
 
 class TextLineTests(EqualityTestsMixin,

--- a/src/zope/schema/tests/test__bootstrapfields.py
+++ b/src/zope/schema/tests/test__bootstrapfields.py
@@ -964,7 +964,7 @@ class TextTests(EqualityTestsMixin,
         self.assertEqual(txt.fromUnicode(deadbeef), deadbeef)
 
     def test_normalization(self):
-        deadbeef = unicodedata.normalize('NFD', b'\xc3\x84\xc3\x96\xc3\x9c'.decode('utf-8'))
+        deadbeef = unicodedata.normalize('NFD', str(b'\xc3\x84\xc3\x96\xc3\x9c', 'utf-8'))
         txt = self._makeOne()
         self.assertEqual(
             [unicodedata.name(c) for c in txt.fromUnicode(deadbeef)],


### PR DESCRIPTION
This fix solves #86, normalization of unicode. Unicode will be normalized to NFC
(Normalization Form Canonical Composition) as long as suppress_unicode_normalization isn't given. This change affects (base-) class Text.