### PR TITLE
IFieldUpdatedEvent not correctly implemented by FieldUpdatedEvent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,8 @@
 
 - Add support for Python 3.9.
 
-- Fix FieldUpdateEvent implementation by having an `object` attribute as the
-  `IFieldUpdatedEvent` interfaces claims there should be.
+- Fix FieldUpdateEvent implementation by having an ``object`` attribute as the
+  ``IFieldUpdatedEvent`` interfaces claims there should be.
 
 6.0.0 (2020-03-21)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Add support for Python 3.9.
 
+- Fix FieldUpdateEvent implementation by having an `object` attribute as the
+  `IFieldUpdatedEvent` interfaces claims there should be.
 
 6.0.0 (2020-03-21)
 ==================

--- a/src/zope/schema/fieldproperty.py
+++ b/src/zope/schema/fieldproperty.py
@@ -33,10 +33,13 @@ class FieldUpdatedEvent(object):
         self.field = field
         self.old_value = old_value
         self.new_value = new_value
-        # The implementation used to differ from the interfaces in that it
-        # declared `self.inst` instead of `self.object`. Leave `self.inst`
-        # in place for backwards compat.
-        self.inst = obj
+
+    # The implementation used to differ from the interfaces in that it
+    # declared `self.inst` instead of `self.object`. Leave `self.inst`
+    # in place for backwards compat.
+    inst = property(
+        lambda self: self.object,
+        lambda self, new_value: setattr(self, 'object', new_value))
 
 
 class FieldProperty(object):

--- a/src/zope/schema/fieldproperty.py
+++ b/src/zope/schema/fieldproperty.py
@@ -28,11 +28,15 @@ _marker = object()
 @interface.implementer(interfaces.IFieldUpdatedEvent)
 class FieldUpdatedEvent(object):
 
-    def __init__(self, inst, field, old_value, new_value):
-        self.inst = inst
+    def __init__(self, obj, field, old_value, new_value):
+        self.object = obj
         self.field = field
         self.old_value = old_value
         self.new_value = new_value
+        # The implementation used to differ from the interfaces in that it
+        # declared `self.inst` instead of `self.object`. Leave `self.inst`
+        # in place for backwards compat.
+        self.inst = obj
 
 
 class FieldProperty(object):

--- a/src/zope/schema/tests/test_fieldproperty.py
+++ b/src/zope/schema/tests/test_fieldproperty.py
@@ -286,13 +286,18 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
         self.assertTrue(verifyObject(IFieldUpdatedEvent, event))
         self.assertEqual(event.object, field)
-        self.assertEqual(event.inst, field)   # BBB, but test it works.
         self.assertEqual(event.old_value, 0)
         self.assertEqual(event.new_value, 0)
         self.assertEqual(
             [ev.field.__name__ for ev in log],
             ['min_length', 'max_length', 'title', 'description', 'required',
              'readonly'])
+        # BBB, but test this works.
+        self.assertEqual(event.inst, field)
+        marker = object()
+        event.inst = marker
+        self.assertEqual(event.inst, marker)
+        self.assertEqual(event.object, marker)
 
     def test_field_event_update(self):
         from zope.schema import Text
@@ -321,10 +326,15 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
         self.assertTrue(verifyObject(IFieldUpdatedEvent, event))
         self.assertEqual(event.object, foo)
-        self.assertEqual(event.inst, foo)   # BBB, but test it works.
         self.assertEqual(event.field, field)
         self.assertEqual(event.old_value, u'Bar')
         self.assertEqual(event.new_value, u'Foo')
+        # BBB, but test this works.
+        self.assertEqual(event.inst, foo)
+        marker = object()
+        event.inst = marker
+        self.assertEqual(event.inst, marker)
+        self.assertEqual(event.object, marker)
 
 
 class FieldPropertyStoredThroughFieldTests(_Base, _Integration):

--- a/src/zope/schema/tests/test_fieldproperty.py
+++ b/src/zope/schema/tests/test_fieldproperty.py
@@ -283,7 +283,7 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertEqual(len(log), 6)
         event = log[0]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
-        self.assertEqual(event.inst, field)
+        self.assertEqual(event.object, field)
         self.assertEqual(event.old_value, 0)
         self.assertEqual(event.new_value, 0)
         self.assertEqual(
@@ -315,7 +315,7 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertEqual(len(log), 2)
         event = log[1]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
-        self.assertEqual(event.inst, foo)
+        self.assertEqual(event.object, foo)
         self.assertEqual(event.field, field)
         self.assertEqual(event.old_value, u'Bar')
         self.assertEqual(event.new_value, u'Foo')
@@ -583,7 +583,7 @@ class FieldPropertyStoredThroughFieldTests(_Base, _Integration):
         self.assertEqual(len(log), 2)
         event = log[1]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
-        self.assertEqual(event.inst, foo)
+        self.assertEqual(event.object, foo)
         self.assertEqual(event.field, field)
         self.assertEqual(event.old_value, u'Bar')
         self.assertEqual(event.new_value, u'Foo')
@@ -613,7 +613,7 @@ class FieldPropertyStoredThroughFieldTests(_Base, _Integration):
              'readonly'])
         event = log[0]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
-        self.assertEqual(event.inst, field)
+        self.assertEqual(event.object, field)
         self.assertEqual(event.old_value, 0)
         self.assertEqual(event.new_value, 0)
 

--- a/src/zope/schema/tests/test_fieldproperty.py
+++ b/src/zope/schema/tests/test_fieldproperty.py
@@ -267,8 +267,9 @@ class FieldPropertyTests(_Base, _Integration):
 
     def test_field_event(self):
         from zope.schema import Text
-
+        from zope.interface.verify import verifyObject
         from zope.event import subscribers
+        from zope.schema.interfaces import IFieldUpdatedEvent
         from zope.schema.fieldproperty import FieldUpdatedEvent
         log = []
         subscribers.append(log.append)
@@ -283,7 +284,9 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertEqual(len(log), 6)
         event = log[0]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
+        self.assertTrue(verifyObject(IFieldUpdatedEvent, event))
         self.assertEqual(event.object, field)
+        self.assertEqual(event.inst, field)   # BBB, but test it works.
         self.assertEqual(event.old_value, 0)
         self.assertEqual(event.new_value, 0)
         self.assertEqual(
@@ -293,8 +296,9 @@ class FieldPropertyTests(_Base, _Integration):
 
     def test_field_event_update(self):
         from zope.schema import Text
-
+        from zope.interface.verify import verifyObject
         from zope.event import subscribers
+        from zope.schema.interfaces import IFieldUpdatedEvent
         from zope.schema.fieldproperty import FieldUpdatedEvent
         field = Text(
             __name__='testing',
@@ -315,7 +319,9 @@ class FieldPropertyTests(_Base, _Integration):
         self.assertEqual(len(log), 2)
         event = log[1]
         self.assertTrue(isinstance(event, FieldUpdatedEvent))
+        self.assertTrue(verifyObject(IFieldUpdatedEvent, event))
         self.assertEqual(event.object, foo)
+        self.assertEqual(event.inst, foo)   # BBB, but test it works.
         self.assertEqual(event.field, field)
         self.assertEqual(event.old_value, u'Bar')
         self.assertEqual(event.new_value, u'Foo')


### PR DESCRIPTION
Fix FieldUpdateEvent implementation by having an `object` attribute as the `IFieldUpdatedEvent` interfaces claims there should be. Fixes #102