### PR TITLE
Add needed check-manifest ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,14 @@ bin/
 build/
 coverage.xml
 develop-eggs/
+develop/
 dist/
 docs/_build
 eggs/
-htmlcov/
+etc/
 lib/
 lib64
+log/
 parts/
 pyvenv.cfg
+var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "5b7a5e11f3a182cb3704ef1e071f9d592a741787"
+commit-id = "20e717f131ccaa1bc2dd878ba90c4be22d4c7488"
 
 [python]
 with-appveyor = false
@@ -17,4 +17,9 @@ fail-under = 100
 [coverage-run]
 additional-config = [
     "omit = src/zope/__init__.py",
+    ]
+
+[check-manifest]
+additional-ignores = [
+    "docs/_static",
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,4 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/doctest/*
+    docs/_static

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [tox]
+minversion = 3.18
 envlist =
     lint
     py27
@@ -39,17 +40,23 @@ commands =
 
 [testenv:docs]
 basepython = python3
+skip_install = false
+deps =
+commands_pre =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 
 [testenv:coverage]
 basepython = python3
+allowlist_externals =
+    mkdir
 deps =
     coverage
     coverage-python-version
     zope.testrunner
 commands =
+    mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src []
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
     coverage html
@@ -73,4 +80,4 @@ exclude_lines =
     raise AssertionError
 
 [coverage:html]
-directory = htmlcov
+directory = parts/htmlcov


### PR DESCRIPTION
Without the additional ignore `check-manifest` fails when running zest.releasers's `fullrelease` script:

```
missing from sdist:
  docs/_static
```
