### PR TITLE
Fix fallback when zope.i18nmessageid is not installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 7.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix fallback when ``zope.i18nmessageid`` is not installed (regression
+  introduced in 7.0.0).
 
 
 7.0.0 (2023-01-01)

--- a/src/zope/schema/_messageid.py
+++ b/src/zope/schema/_messageid.py
@@ -14,7 +14,7 @@
 
 try:
     from zope.i18nmessageid import MessageFactory
-except ImportError:  # pragma: no cover
-    MessageFactory = str
-else:  # pragma: no cover
+except ImportError:
+    _ = str
+else:
     _ = MessageFactory("zope")

--- a/src/zope/schema/tests/test__messageid.py
+++ b/src/zope/schema/tests/test__messageid.py
@@ -1,0 +1,46 @@
+##############################################################################
+#
+# Copyright (c) 2023 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import importlib
+import types
+import unittest
+from unittest.mock import patch
+
+from zope.i18nmessageid import Message
+
+from zope.schema import _messageid
+
+
+class MessageIDTests(unittest.TestCase):
+
+    def test_with_zope_i18nmessageid(self):
+        # zope.i18nmessageid is installed while running tests, so `_`
+        # returns instances of `Message` by default.
+        message = _messageid._("test string")
+        self.assertIsInstance(message, Message)
+        self.assertEqual("zope", message.domain)
+        self.assertEqual("test string", message)
+
+    def test_without_zope_i18nmessageid(self):
+        # If we pretend that zope.i18nmessageid is not installed, then `_`
+        # falls back to returning instances of `str`.
+        module = types.ModuleType("zope.i18nmessageid")
+        try:
+            with patch.dict("sys.modules", {"zope.i18nmessageid": module}):
+                importlib.reload(_messageid)
+                message = _messageid._("test string")
+                self.assertNotIsInstance(message, Message)
+                self.assertEqual("test string", message)
+        finally:
+            importlib.reload(_messageid)


### PR DESCRIPTION
I introduced this regression in
https://github.com/zopefoundation/zope.schema/pull/118 by misreading the try/except/else logic in `zope.schema._messageid`.  The new tests should guard against somebody else making a similar mistake in future.